### PR TITLE
Wasm fix

### DIFF
--- a/bracket-random/Cargo.toml
+++ b/bracket-random/Cargo.toml
@@ -26,10 +26,10 @@ lazy_static = { version = "1.4.0", optional = true }
 serde_crate = { version = "~1.0.110", features = ["derive"], optional = true, package = "serde" }
 
 [target.wasm32-unknown-unknown.dependencies]
-rand = { version = "0.8.3" }
+rand = { version = "0.8.3", default-features = false }
 
 [target.'cfg(not(any(target_arch = "wasm32")))'.dependencies]
-rand = "0.8.3"
+rand = { version = "0.8.3", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3.4"

--- a/bracket-random/Cargo.toml
+++ b/bracket-random/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bracket-random"
-version = "0.8.2"
+version = "0.8.3"
 authors = ["Herbert Wolverson <herberticus@gmail.com>"]
 edition = "2018"
 publish = true

--- a/bracket-random/Cargo.toml
+++ b/bracket-random/Cargo.toml
@@ -24,11 +24,6 @@ rand_xorshift = { version = "0.3.0" }
 regex = { version = "1.3.6", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 serde_crate = { version = "~1.0.110", features = ["derive"], optional = true, package = "serde" }
-
-[target.wasm32-unknown-unknown.dependencies]
-rand = { version = "0.8.3", default-features = false }
-
-[target.'cfg(not(any(target_arch = "wasm32")))'.dependencies]
 rand = { version = "0.8.3", default-features = false }
 
 [dev-dependencies]

--- a/bracket-random/src/parsing.rs
+++ b/bracket-random/src/parsing.rs
@@ -6,7 +6,11 @@ use std::fmt;
 use serde_crate::{Deserialize, Serialize};
 
 // Describes a dice roll type
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(crate="serde_crate"))]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct DiceType {
     pub n_dice: i32,
@@ -137,7 +141,7 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn serialize_parsing() {
-        use serde_crate::{Serialize, Deserialize};
+        use serde_crate::{Deserialize, Serialize};
         let d = parse_dice_string("3d6 - 2").unwrap();
         let serialized = serde_json::to_string(&d).unwrap();
         let deserialized: DiceType = serde_json::from_str(&serialized).unwrap();

--- a/bracket-random/src/random.rs
+++ b/bracket-random/src/random.rs
@@ -21,7 +21,12 @@ impl RandomNumberGenerator {
     #[allow(clippy::new_without_default)] // XorShiftRng doesn't have a Default, so we don't either
     pub fn new() -> RandomNumberGenerator {
         use std::time::{SystemTime, UNIX_EPOCH};
-        let rng: XorShiftRng = SeedableRng::seed_from_u64(SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() as u64);
+        let rng: XorShiftRng = SeedableRng::seed_from_u64(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as u64,
+        );
         RandomNumberGenerator { rng }
     }
 

--- a/bracket-random/src/random.rs
+++ b/bracket-random/src/random.rs
@@ -20,7 +20,8 @@ impl RandomNumberGenerator {
     /// Creates a new RNG from a randomly generated seed
     #[allow(clippy::new_without_default)] // XorShiftRng doesn't have a Default, so we don't either
     pub fn new() -> RandomNumberGenerator {
-        let rng: XorShiftRng = SeedableRng::from_entropy();
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let rng: XorShiftRng = SeedableRng::seed_from_u64(SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() as u64);
         RandomNumberGenerator { rng }
     }
 

--- a/bracket-terminal/Cargo.toml
+++ b/bracket-terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bracket-terminal"
-version = "0.8.2"
+version = "0.8.3"
 authors = ["Herbert Wolverson <herberticus@gmail.com>"]
 edition = "2018"
 publish = true

--- a/bracket-terminal/Cargo.toml
+++ b/bracket-terminal/Cargo.toml
@@ -29,7 +29,7 @@ pancurses = { version = "0.16.1", optional = true }
 amethyst = { version = "=0.15.0", features = [ "tiles" ], optional = true }
 ultraviolet = "~0.7.5"
 parking_lot = { version = "~0.11.1" }
-ctrlc = { version = "~3.1" }
+ctrlc = { version = "~3.1", optional=true }
 
 [target.'cfg(not(any(target_arch = "wasm32")))'.dependencies]
 glutin = {version = "0.26.0", optional = true }
@@ -38,9 +38,10 @@ winit = { version = "0.24.0" }
 [features]
 default = [ "opengl" ]
 opengl = [ "glow", "image", "glutin" ]
-curses = [ "pancurses" ]
+curses = [ "pancurses", "ctrlc" ]
 amethyst_engine_vulkan = [ "amethyst/vulkan", "image" ]
 amethyst_engine_metal = [ "amethyst/metal", "image" ]
+# TODO: Add crossterm optional ctrlc
 
 [dev-dependencies]
 bracket-random = { path = "../bracket-random", version = "~0.8.2" }
@@ -54,7 +55,7 @@ web-sys = { version = "0.3", features=["console", "Attr", "CanvasRenderingContex
     "MouseEvent"] }
 wasm-bindgen = "0.2"
 wasm-timer = "0.1.0"
-rand = { version = "0.8.3" }
+rand = { version = "0.8.3", default-features = false }
 console_error_panic_hook = "0.1.6"
 winit = { version = "0.24.0", features = [ "web-sys" ] }
 

--- a/bracket-terminal/Cargo.toml
+++ b/bracket-terminal/Cargo.toml
@@ -39,9 +39,9 @@ winit = { version = "0.24.0" }
 default = [ "opengl" ]
 opengl = [ "glow", "image", "glutin" ]
 curses = [ "pancurses", "ctrlc" ]
+cross_term = [ "crossterm", "ctrlc" ]
 amethyst_engine_vulkan = [ "amethyst/vulkan", "image" ]
 amethyst_engine_metal = [ "amethyst/metal", "image" ]
-# TODO: Add crossterm optional ctrlc
 
 [dev-dependencies]
 bracket-random = { path = "../bracket-random", version = "~0.8.2" }

--- a/bracket-terminal/README.md
+++ b/bracket-terminal/README.md
@@ -73,4 +73,4 @@ You can run the `dwarfmap` example with different back-ends like this. The same 
 * *Amethyst (Vulkan)*: `cargo run --example dwarfmap --no-default-features --features "amethyst_engine_vulkan"`
 * *Amethyst (Metal)*: `cargo run --example dwarfmap --no-default-features --features "amethyst_engine_metal"`
 * *Curses*: `cargo run --example dwarfmap --no-default-features --features "curses"`
-* *Crossterm*: `cargo run --example dwarfmap --no-default-features --features "crossterm"`
+* *Crossterm*: (note that the feature is called `cross_term`) `cargo run --example dwarfmap --no-default-features --features "cross_term"`

--- a/bracket-terminal/src/hal/mod.rs
+++ b/bracket-terminal/src/hal/mod.rs
@@ -25,10 +25,10 @@ mod curses;
 pub use curses::*;
 
 #[cfg(not(feature = "opengl"))]
-#[cfg(all(not(feature = "opengl"), feature = "crossterm"))]
+#[cfg(all(not(feature = "opengl"), feature = "cross_term"))]
 mod crossterm_be;
 
-#[cfg(all(not(feature = "opengl"), feature = "crossterm"))]
+#[cfg(all(not(feature = "opengl"), feature = "cross_term"))]
 pub use crossterm_be::*;
 
 #[cfg(all(


### PR DESCRIPTION
#194 - Stop using `getrandom` from the `rand` crate, because WASM32 (and other platforms) don't support it. Bump version numbers ready for release.