### PR TITLE
Feature: make bracket-geometry distance algorithms copyable

### DIFF
--- a/bracket-geometry/src/distance.rs
+++ b/bracket-geometry/src/distance.rs
@@ -90,7 +90,10 @@ fn distance3d_pythagoras(start: Point3, end: Point3) -> f32 {
 
 // Calculates a diagonal distance
 fn distance2d_diagonal(start: Point, end: Point) -> f32 {
-    i32::max((start.x - end.x).abs(), (start.y - end.y).abs()) as f32
+    i32::max(
+        (start.x - end.x).abs(),
+        (start.y - end.y).abs()
+    ) as f32
 }
 
 fn distance3d_diagonal(start: Point3, end: Point3) -> f32 {

--- a/bracket-geometry/src/distance.rs
+++ b/bracket-geometry/src/distance.rs
@@ -8,7 +8,7 @@ pub enum DistanceAlg {
     PythagorasSquared,
     Manhattan,
     Chebyshev,
-    Diagonal,
+    Diagonal
 }
 
 impl DistanceAlg {
@@ -19,7 +19,7 @@ impl DistanceAlg {
             DistanceAlg::PythagorasSquared => distance2d_pythagoras_squared(start, end),
             DistanceAlg::Manhattan => distance2d_manhattan(start, end),
             DistanceAlg::Chebyshev => distance2d_chebyshev(start, end),
-            DistanceAlg::Diagonal => distance2d_diagonal(start, end),
+            DistanceAlg::Diagonal => distance2d_diagonal(start, end)
         }
     }
     /// Provides a 3D distance between points, using the specified algorithm.
@@ -29,7 +29,7 @@ impl DistanceAlg {
             DistanceAlg::PythagorasSquared => distance3d_pythagoras_squared(start, end),
             DistanceAlg::Manhattan => distance3d_manhattan(start, end),
             DistanceAlg::Chebyshev => distance3d_pythagoras(start, end),
-            DistanceAlg::Diagonal => distance3d_diagonal(start, end),
+            DistanceAlg::Diagonal => distance3d_diagonal(start, end)
         }
     }
 }
@@ -96,7 +96,10 @@ fn distance2d_diagonal(start: Point, end: Point) -> f32 {
 fn distance3d_diagonal(start: Point3, end: Point3) -> f32 {
     i32::max(
         (start.x - end.x).abs(),
-        i32::max((start.y - end.y).abs(), (start.z - end.z).abs()),
+        i32::max(
+            (start.y - end.y).abs(),
+            (start.z - end.z).abs()
+        )
     ) as f32
 }
 

--- a/bracket-geometry/src/distance.rs
+++ b/bracket-geometry/src/distance.rs
@@ -2,12 +2,13 @@ use crate::prelude::{Point, Point3};
 use std::cmp::{max, min};
 
 /// Enumeration of available 2D Distance algorithms
+#[derive(Clone, Copy)]
 pub enum DistanceAlg {
     Pythagoras,
     PythagorasSquared,
     Manhattan,
     Chebyshev,
-    Diagonal
+    Diagonal,
 }
 
 impl DistanceAlg {
@@ -18,7 +19,7 @@ impl DistanceAlg {
             DistanceAlg::PythagorasSquared => distance2d_pythagoras_squared(start, end),
             DistanceAlg::Manhattan => distance2d_manhattan(start, end),
             DistanceAlg::Chebyshev => distance2d_chebyshev(start, end),
-            DistanceAlg::Diagonal => distance2d_diagonal(start, end)
+            DistanceAlg::Diagonal => distance2d_diagonal(start, end),
         }
     }
     /// Provides a 3D distance between points, using the specified algorithm.
@@ -28,7 +29,7 @@ impl DistanceAlg {
             DistanceAlg::PythagorasSquared => distance3d_pythagoras_squared(start, end),
             DistanceAlg::Manhattan => distance3d_manhattan(start, end),
             DistanceAlg::Chebyshev => distance3d_pythagoras(start, end),
-            DistanceAlg::Diagonal => distance3d_diagonal(start, end)
+            DistanceAlg::Diagonal => distance3d_diagonal(start, end),
         }
     }
 }
@@ -89,19 +90,13 @@ fn distance3d_pythagoras(start: Point3, end: Point3) -> f32 {
 
 // Calculates a diagonal distance
 fn distance2d_diagonal(start: Point, end: Point) -> f32 {
-    i32::max(
-        (start.x - end.x).abs(),
-        (start.y - end.y).abs()
-    ) as f32
+    i32::max((start.x - end.x).abs(), (start.y - end.y).abs()) as f32
 }
 
 fn distance3d_diagonal(start: Point3, end: Point3) -> f32 {
     i32::max(
         (start.x - end.x).abs(),
-        i32::max(
-            (start.y - end.y).abs(),
-            (start.z - end.z).abs()
-        )
+        i32::max((start.y - end.y).abs(), (start.z - end.z).abs()),
     ) as f32
 }
 
@@ -216,5 +211,20 @@ mod tests {
 
         d = DistanceAlg::Chebyshev.distance2d(Point::new(0, 0), Point::new(5, 5));
         assert!(f32::abs(d - 5.0) < std::f32::EPSILON);
+    }
+
+    #[test]
+    fn test_algorithm_from_shared_reference() {
+        let mut algorithm = DistanceAlg::Chebyshev;
+        let mut d = algorithm.distance2d(Point::new(0, 0), Point::new(5, 5));
+        assert!(f32::abs(d - 5.0) < std::f32::EPSILON);
+
+        algorithm = DistanceAlg::Manhattan;
+        d = algorithm.distance2d(Point::new(0, 0), Point::new(5, 5));
+        assert!(f32::abs(d - 10.0) < std::f32::EPSILON);
+
+        let shared_ref = &algorithm;
+        d = shared_ref.distance2d(Point::new(0, 0), Point::new(5, 5));
+        assert!(f32::abs(d - 10.0) < std::f32::EPSILON);
     }
 }


### PR DESCRIPTION
⚠️ First Rust PR. May contain newbity. ⚠️ 

This PR adds Copy and Clone to DistanceAlg.

Suppose a user function creates a map builder, specifying a distance algorithm to be used within.
```
struct Builder {
   pub distance_algorithm: DistanceAlg;
};
```

The builder would ideally be able to employ the algorithm without having to match against all known distance algorithms:
```
impl Builder {
    fn build(&self, ...) {
        ...
        let distance = self.distance_algorithm.distance_2d(origin, destination);
    }
}
```

However, if `distance_algorithm` ends up behind a shared reference, and does not implement Copy, the caller must do this instead:
```
impl Builder {
    fn build(&self, ...) {
        ...
        let distance = match self.distance_algorithm {
            DistanceAlg::Pythagoras => DistanceAlg::Pythagoras::distance_2d(origin, destination),
            DistanceAlg::PythagorasSquared => DistanceAlg::PythagorasSquared::distance_2d(origin, destination),
            ....
        }
    }
}
```
