### PR TITLE
Add tile_width and tile_height fields to BTerm.

### DIFF
--- a/bracket-terminal/src/bterm.rs
+++ b/bracket-terminal/src/bterm.rs
@@ -64,6 +64,8 @@ pub struct BTerm {
     pub height_pixels: u32,
     pub original_height_pixels: u32,
     pub original_width_pixels: u32,
+    pub tile_width: u32,
+    pub tile_height: u32,
     pub fps: f32,
     pub frame_time_ms: f32,
     pub active_console: usize,
@@ -83,22 +85,27 @@ pub struct BTerm {
 impl BTerm {
     /// Initializes an OpenGL context and a window, stores the info in the BTerm structure.
     pub fn init_raw<S: ToString, T>(
-        width_pixels: T,
-        height_pixels: T,
+        chars_width: T,
+        tile_width: T,
+        chars_height: T,
+        tile_height: T,
         window_title: S,
         platform_hints: InitHints,
     ) -> BResult<BTerm>
     where
         T: TryInto<u32>,
     {
-        let w = width_pixels.try_into();
-        let h = height_pixels.try_into();
-        let (w, h) = if let (Ok(w), Ok(h)) = (w, h) {
-            (w, h)
+        let chars_w = chars_width.try_into();
+        let chars_h = chars_height.try_into();
+        let tile_w = tile_width.try_into();
+        let tile_h = tile_height.try_into();
+
+        let (chars_w, chars_h, tile_w, tile_h) = if let (Ok(chars_w), Ok(chars_h), Ok(tile_w), Ok(tile_h)) = (chars_w, chars_h, tile_w, tile_h) {
+            (chars_w, chars_h, tile_w, tile_h)
         } else {
             return Err("Couldn't convert to u32".into());
         };
-        Ok(init_raw(w, h, window_title, platform_hints)?)
+        Ok(init_raw(chars_w, tile_w, chars_h, tile_h, window_title, platform_hints)?)
     }
 
     /// Quick initialization for when you just want an 8x8 font terminal
@@ -118,7 +125,7 @@ impl BTerm {
         let w: u32 = width_chars.try_into().ok().unwrap();
         let h: u32 = height_chars.try_into().ok().unwrap();
         let font_path = format!("{}/terminal8x8.png", &path_to_shaders.to_string());
-        let mut context = BTerm::init_raw(w * 8, h * 8, window_title, InitHints::new()).unwrap();
+        let mut context = BTerm::init_raw(w, 8, h, 8, window_title, InitHints::new()).unwrap();
         let font = context.register_font(Font::load(font_path, (8, 8), None));
         context.register_console(SimpleConsole::init(w, h), font.unwrap());
         context
@@ -141,7 +148,7 @@ impl BTerm {
         let w: u32 = width_chars.try_into().ok().unwrap();
         let h: u32 = height_chars.try_into().ok().unwrap();
         let font_path = format!("{}/vga8x16.png", &path_to_shaders.to_string());
-        let mut context = BTerm::init_raw(w * 8, h * 16, window_title, InitHints::new()).unwrap();
+        let mut context = BTerm::init_raw(w, 8, h, 16, window_title, InitHints::new()).unwrap();
         let font = context.register_font(Font::load(font_path, (8, 16), None));
         context.register_console(SimpleConsole::init(w, h), font.unwrap());
         context

--- a/bracket-terminal/src/hal/native/init.rs
+++ b/bracket-terminal/src/hal/native/init.rs
@@ -6,11 +6,17 @@ use crate::BResult;
 use glutin::{dpi::LogicalSize, event_loop::EventLoop, window::WindowBuilder, ContextBuilder};
 
 pub fn init_raw<S: ToString>(
-    width_pixels: u32,
-    height_pixels: u32,
+    chars_width: u32,
+    tile_width: u32,
+    chars_height: u32,
+    tile_height: u32,
     window_title: S,
     platform_hints: InitHints,
 ) -> BResult<BTerm> {
+
+    let width_pixels = chars_width * tile_width;
+    let height_pixels = chars_height * tile_height;
+
     let el = EventLoop::new();
     let wb = WindowBuilder::new()
         .with_title(window_title.to_string())
@@ -104,6 +110,8 @@ pub fn init_raw<S: ToString>(
         height_pixels,
         original_width_pixels: width_pixels,
         original_height_pixels: height_pixels,
+        tile_width,
+        tile_height,
         fps: 0.0,
         frame_time_ms: 0.0,
         active_console: 0,

--- a/bracket-terminal/src/initializer.rs
+++ b/bracket-terminal/src/initializer.rs
@@ -486,8 +486,10 @@ impl BTermBuilder {
     /// Combine all of the builder parameters, and return an BTerm context ready to go.
     pub fn build(self) -> BResult<BTerm> {
         let mut context = init_raw(
-            self.width * self.tile_width,
-            self.height * self.tile_height,
+            self.width,
+            self.tile_width,
+            self.height,
+            self.tile_height,
             self.title.unwrap_or_else(|| "BTerm Window".to_string()),
             self.platform_hints,
         )?;


### PR DESCRIPTION
These fields will assist with roguelike helper functions relating to movement by avoiding hardcoded values such as 80 and 50 when using BTermBuilder::simple80x50().