### PR TITLE
update glow dependency

### DIFF
--- a/bracket-terminal/Cargo.toml
+++ b/bracket-terminal/Cargo.toml
@@ -22,7 +22,7 @@ flate2 = "1.0.20"
 lazy_static = "1.4.0"
 object-pool = "0.5.3"
 byteorder = "1.4.2"
-glow = { version = "0.4.0", optional = true }
+glow = { version = "0.10.0", optional = true }
 image = { version = "0.23.12", default-features = false, features = ["jpeg", "png"], optional = true }
 crossterm = { version = "~0.19", optional = true }
 pancurses = { version = "0.16.1", optional = true }

--- a/bracket-terminal/src/hal/gl_common/shader.rs
+++ b/bracket-terminal/src/hal/gl_common/shader.rs
@@ -69,21 +69,24 @@ impl Shader {
     /// utility uniform functions
     /// ------------------------------------------------------------------------
     pub unsafe fn setBool(&self, gl: &glow::Context, name: &str, value: bool) {
-        gl.uniform_1_i32(gl.get_uniform_location(self.ID, name), value as i32);
+        gl.uniform_1_i32(
+            gl.get_uniform_location(self.ID, name).as_ref(),
+            value as i32,
+        );
     }
 
     #[allow(non_snake_case)]
     #[allow(clippy::missing_safety_doc)]
     /// ------------------------------------------------------------------------
     pub unsafe fn setInt(&self, gl: &glow::Context, name: &str, value: i32) {
-        gl.uniform_1_i32(gl.get_uniform_location(self.ID, name), value);
+        gl.uniform_1_i32(gl.get_uniform_location(self.ID, name).as_ref(), value);
     }
 
     #[allow(non_snake_case)]
     #[allow(clippy::missing_safety_doc)]
     /// ------------------------------------------------------------------------
     pub unsafe fn setFloat(&self, gl: &glow::Context, name: &str, value: f32) {
-        gl.uniform_1_f32(gl.get_uniform_location(self.ID, name), value);
+        gl.uniform_1_f32(gl.get_uniform_location(self.ID, name).as_ref(), value);
     }
 
     #[allow(non_snake_case)]
@@ -91,7 +94,7 @@ impl Shader {
     /// ------------------------------------------------------------------------
     pub unsafe fn setVector3(&self, gl: &glow::Context, name: &str, value: &Vec3) {
         gl.uniform_3_f32(
-            gl.get_uniform_location(self.ID, name),
+            gl.get_uniform_location(self.ID, name).as_ref(),
             value.x,
             value.y,
             value.z,
@@ -102,20 +105,20 @@ impl Shader {
     #[allow(clippy::missing_safety_doc)]
     /// ------------------------------------------------------------------------
     pub unsafe fn setVec3(&self, gl: &glow::Context, name: &str, x: f32, y: f32, z: f32) {
-        gl.uniform_3_f32(gl.get_uniform_location(self.ID, name), x, y, z);
+        gl.uniform_3_f32(gl.get_uniform_location(self.ID, name).as_ref(), x, y, z);
     }
 
     #[allow(non_snake_case)]
     #[allow(clippy::missing_safety_doc)]
     /// ------------------------------------------------------------------------
     pub unsafe fn setVec2(&self, gl: &glow::Context, name: &str, x: f32, y: f32) {
-        gl.uniform_2_f32(gl.get_uniform_location(self.ID, name), x, y);
+        gl.uniform_2_f32(gl.get_uniform_location(self.ID, name).as_ref(), x, y);
     }
 
     #[allow(non_snake_case)]
     #[allow(clippy::missing_safety_doc)]
     /// ------------------------------------------------------------------------
     pub unsafe fn setMat4(&self, gl: &glow::Context, name: &str, mat: &[f32; 16]) {
-        gl.uniform_matrix_4_f32_slice(gl.get_uniform_location(self.ID, name), false, mat);
+        gl.uniform_matrix_4_f32_slice(gl.get_uniform_location(self.ID, name).as_ref(), false, mat);
     }
 }

--- a/bracket-terminal/src/hal/native/init.rs
+++ b/bracket-terminal/src/hal/native/init.rs
@@ -37,9 +37,11 @@ pub fn init_raw<S: ToString>(
         }
     }
 
-    let gl = glow::Context::from_loader_function(|ptr| {
-        windowed_context.get_proc_address(ptr) as *const _
-    });
+    let gl = unsafe {
+        glow::Context::from_loader_function(|ptr| {
+            windowed_context.get_proc_address(ptr) as *const _
+        })
+    };
 
     // Load our basic shaders
     let mut shaders: Vec<Shader> = Vec::new();

--- a/bracket-terminal/src/hal/native/mainloop.rs
+++ b/bracket-terminal/src/hal/native/mainloop.rs
@@ -341,7 +341,7 @@ fn tock<GS: GameState>(
                     h as i32,
                     glow::RGBA,
                     glow::UNSIGNED_BYTE,
-                    pixels,
+                    glow::PixelPackData::Slice(pixels),
                 );
             }
 


### PR DESCRIPTION
The version of glow that bracket-lib was using depended on a yanked version of `slotmap`.  This updates glow to the most recent version.

Please see https://github.com/grovesNL/glow/issues/179 for the instigating report.