### PR TITLE
Scaler2

### DIFF
--- a/bracket-terminal/src/hal/gl_common/backing/fancy_console_backing.rs
+++ b/bracket-terminal/src/hal/gl_common/backing/fancy_console_backing.rs
@@ -77,28 +77,27 @@ impl FancyConsoleBackend {
         self.vao.index_buffer.clear();
 
         let mut index_count: i32 = 0;
-        /*let step_x: f32 = scale * 2.0 / width as f32;
-        let step_y: f32 = scale * 2.0 / height as f32;
+        //let step_x: f32 = scale * 2.0 / width as f32;
+        //let step_y: f32 = scale * 2.0 / height as f32;
 
         let screen_x_start: f32 = -1.0 * scale
             - 2.0 * (scale_center.0 - width as i32 / 2) as f32 * (scale - 1.0) / width as f32;
         let screen_y_start: f32 = -1.0 * scale
-            + 2.0 * (scale_center.1 - height as i32 / 2) as f32 * (scale - 1.0) / height as f32;*/
+            + 2.0 * (scale_center.1 - height as i32 / 2) as f32 * (scale - 1.0) / height as f32;
 
-        let (step_x, step_y, left_x, top_y) = {
+        let (step_x, step_y) = {
             let be = BACKEND.lock();
             let (step_x, step_y) = be.screen_scaler.calc_step(width, height, scale);
-            let (left_x, top_y) = be.screen_scaler.top_left_pixel();
 
-            (step_x, step_y, left_x, top_y)
+            (step_x, step_y)
         };
 
         for t in tiles.iter() {
             let x = t.position.x;
             let y = t.position.y;
 
-            let screen_x = ((step_x * x) + left_x) + offset_x;
-            let screen_y = ((step_y * y) + top_y) + offset_y;
+            let screen_x = ((step_x * x) + screen_x_start) + offset_x;
+            let screen_y = ((step_y * y) + screen_y_start) + offset_y;
             let fg = t.fg;
             let bg = t.bg;
             let glyph = t.glyph;

--- a/bracket-terminal/src/hal/gl_common/backing/simple_console_backing.rs
+++ b/bracket-terminal/src/hal/gl_common/backing/simple_console_backing.rs
@@ -112,21 +112,22 @@ impl SimpleConsoleBackend {
         self.vertex_counter = 0;
         self.index_counter = 0;
 
-        let (step_x, step_y, left_x, top_y) = {
+        let (step_x, step_y) = {
             let be = BACKEND.lock();
             let (step_x, step_y) = be.screen_scaler.calc_step(width, height, scale);
-            let (left_x, top_y) = be.screen_scaler.top_left_pixel();
 
-            (step_x, step_y, left_x, top_y)
+            (step_x, step_y)
         };
 
         //let step_x: f32 = scale * 2.0f32 / width as f32;
         //let step_y: f32 = scale * 2.0f32 / height as f32;
 
         let mut index_count: i32 = 0;
-        let mut screen_y: f32 = top_y;
+        let mut screen_y: f32 = -1.0 * scale
+            + 2.0 * (scale_center.1 - height as i32 / 2) as f32 * (scale - 1.0) / height as f32;
         for y in 0..height {
-            let mut screen_x: f32 = left_x;
+            let mut screen_x: f32 = -1.0 * scale
+                - 2.0 * (scale_center.0 - width as i32 / 2) as f32 * (scale - 1.0) / width as f32;
             for x in 0..width {
                 let fg = tiles[((y * width) + x) as usize].fg;
                 let bg = tiles[((y * width) + x) as usize].bg;

--- a/bracket-terminal/src/hal/gl_common/backing/sparse_console_backing.rs
+++ b/bracket-terminal/src/hal/gl_common/backing/sparse_console_backing.rs
@@ -76,28 +76,27 @@ impl SparseConsoleBackend {
         self.vao.vertex_buffer.clear();
         self.vao.index_buffer.clear();
 
-        let (step_x, step_y, left_x, top_y) = {
+        let (step_x, step_y) = {
             let be = BACKEND.lock();
             let (step_x, step_y) = be.screen_scaler.calc_step(width, height, scale);
-            let (left_x, top_y) = be.screen_scaler.top_left_pixel();
 
-            (step_x, step_y, left_x, top_y)
+            (step_x, step_y)
         };
 
         //let step_x: f32 = scale * 2.0 / width as f32;
         //let step_y: f32 = scale * 2.0 / height as f32;
 
         let mut index_count: i32 = 0;
-        //let screen_x_start: f32 = -1.0 * scale
-        //    - 2.0 * (scale_center.0 - width as i32 / 2) as f32 * (scale - 1.0) / width as f32;
-        //let screen_y_start: f32 = -1.0 * scale
-        //    + 2.0 * (scale_center.1 - height as i32 / 2) as f32 * (scale - 1.0) / height as f32;
+        let screen_x_start: f32 = -1.0 * scale
+            - 2.0 * (scale_center.0 - width as i32 / 2) as f32 * (scale - 1.0) / width as f32;
+        let screen_y_start: f32 = -1.0 * scale
+            + 2.0 * (scale_center.1 - height as i32 / 2) as f32 * (scale - 1.0) / height as f32;
         for t in tiles.iter() {
             let x = t.idx % width as usize;
             let y = t.idx / width as usize;
 
-            let screen_x = ((step_x * x as f32) + left_x) + offset_x;
-            let screen_y = ((step_y * y as f32) + top_y) + offset_y;
+            let screen_x = ((step_x * x as f32) + screen_x_start) + offset_x;
+            let screen_y = ((step_y * y as f32) + screen_y_start) + offset_y;
             let fg = t.fg;
             let bg = t.bg;
             let glyph = t.glyph;

--- a/bracket-terminal/src/hal/gl_common/framebuffer.rs
+++ b/bracket-terminal/src/hal/gl_common/framebuffer.rs
@@ -40,12 +40,12 @@ impl Framebuffer {
             gl.tex_parameter_i32(
                 glow::TEXTURE_2D,
                 glow::TEXTURE_MIN_FILTER,
-                glow::LINEAR as i32,
+                glow::NEAREST as i32,
             );
             gl.tex_parameter_i32(
                 glow::TEXTURE_2D,
                 glow::TEXTURE_MAG_FILTER,
-                glow::LINEAR as i32,
+                glow::NEAREST as i32,
             );
             gl.tex_parameter_i32(
                 glow::TEXTURE_2D,

--- a/bracket-terminal/src/hal/gl_common/framebuffer.rs
+++ b/bracket-terminal/src/hal/gl_common/framebuffer.rs
@@ -106,7 +106,7 @@ impl Framebuffer {
             gl.tex_parameter_i32(
                 glow::TEXTURE_2D,
                 glow::TEXTURE_MAG_FILTER,
-                glow::NEAREST as i32,
+                glow::LINEAR as i32,
             );
             gl.tex_parameter_i32(
                 glow::TEXTURE_2D,

--- a/bracket-terminal/src/hal/gl_common/framebuffer.rs
+++ b/bracket-terminal/src/hal/gl_common/framebuffer.rs
@@ -45,7 +45,7 @@ impl Framebuffer {
             gl.tex_parameter_i32(
                 glow::TEXTURE_2D,
                 glow::TEXTURE_MAG_FILTER,
-                glow::NEAREST as i32,
+                glow::LINEAR as i32,
             );
             gl.tex_parameter_i32(
                 glow::TEXTURE_2D,

--- a/bracket-terminal/src/hal/gl_common/quadrender.rs
+++ b/bracket-terminal/src/hal/gl_common/quadrender.rs
@@ -4,11 +4,63 @@ use glow::HasContext;
 /// Sets up a simple VAO/VBO to render a single quad
 /// Used for presenting the backing buffer and in post-process chains.
 pub fn setup_quad(gl: &glow::Context) -> VertexArrayId {
+    #[rustfmt::skip]
     let quad_vertices: [f32; 24] = [
         // vertex attributes for a quad that fills the entire screen in Normalized Device Coordinates.
         // positions // texCoords
-        -1.0, 1.0, 0.0, 1.0, -1.0, -1.0, 0.0, 0.0, 1.0, -1.0, 1.0, 0.0, -1.0, 1.0, 0.0, 1.0, 1.0,
-        -1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0,
+        -1.0,  1.0, 0.0, 1.0,
+        -1.0, -1.0, 0.0, 0.0,
+         1.0, -1.0, 1.0, 0.0,
+        -1.0,  1.0, 0.0, 1.0,
+         1.0, -1.0, 1.0, 0.0,
+         1.0,  1.0, 1.0, 1.0,
+    ];
+    let (vertex_array, vertex_buffer);
+    unsafe {
+        vertex_array = gl.create_vertex_array().unwrap();
+        gl.bind_vertex_array(Some(vertex_array));
+
+        vertex_buffer = gl.create_buffer().unwrap();
+        gl.bind_buffer(glow::ARRAY_BUFFER, Some(vertex_buffer));
+        gl.buffer_data_u8_slice(
+            glow::ARRAY_BUFFER,
+            quad_vertices.align_to::<u8>().1,
+            glow::STATIC_DRAW,
+        );
+
+        gl.enable_vertex_attrib_array(0);
+        gl.bind_buffer(glow::ARRAY_BUFFER, Some(vertex_buffer));
+        let stride = 4 * std::mem::size_of::<f32>() as i32;
+        gl.vertex_attrib_pointer_f32(0, 2, glow::FLOAT, false, stride, 0);
+        gl.enable_vertex_attrib_array(1);
+        gl.vertex_attrib_pointer_f32(
+            1,
+            2,
+            glow::FLOAT,
+            false,
+            stride,
+            2 * std::mem::size_of::<f32>() as i32,
+        );
+
+        gl.bind_vertex_array(None);
+    }
+
+    vertex_array
+}
+
+/// Sets up a simple VAO/VBO to render a single quad
+/// Used for presenting the backing buffer and in post-process chains.
+pub fn setup_quad_gutter(gl: &glow::Context, left: f32, right: f32, top: f32, bottom: f32) -> VertexArrayId {
+    #[rustfmt::skip]
+    let quad_vertices: [f32; 24] = [
+        // vertex attributes for a quad that fills the entire screen in Normalized Device Coordinates.
+        // positions // texCoords
+        left,  top, 0.0, 1.0,
+        left, bottom, 0.0, 0.0,
+        right, bottom, 1.0, 0.0,
+        left,  top, 0.0, 1.0,
+        right, bottom, 1.0, 0.0,
+        right, top, 1.0, 1.0,
     ];
     let (vertex_array, vertex_buffer);
     unsafe {

--- a/bracket-terminal/src/hal/native/init.rs
+++ b/bracket-terminal/src/hal/native/init.rs
@@ -90,8 +90,8 @@ pub fn init_raw<S: ToString>(
     scaler.change_logical_size(width_pixels, height_pixels, initial_dpi_factor as f32);
     let backing_fbo = Framebuffer::build_fbo(
         &gl,
-        scaler.physical_size.0 as i32,
-        scaler.physical_size.1 as i32,
+        scaler.logical_size.0 as i32,
+        scaler.logical_size.1 as i32,
     )?;
 
     // Build a simple quad rendering VAO

--- a/bracket-terminal/src/hal/native/mainloop.rs
+++ b/bracket-terminal/src/hal/native/mainloop.rs
@@ -323,7 +323,7 @@ fn tock<GS: GameState>(
     rebuild_consoles();
 
     // Bind to the backing buffer
-    if bterm.post_scanlines {
+    {
         let be = BACKEND.lock();
         be.backing_buffer
             .as_ref()
@@ -331,7 +331,7 @@ fn tock<GS: GameState>(
             .bind(be.gl.as_ref().unwrap());
     }
 
-    // Clear the screen
+    // Clear the backing buffer
     unsafe {
         let be = BACKEND.lock();
         be.gl.as_ref().unwrap().clear_color(0.0, 0.0, 0.0, 1.0);
@@ -353,7 +353,7 @@ fn tock<GS: GameState>(
         }
     }
 
-    if bterm.post_scanlines {
+    {
         // Now we return to the primary screen
         let be = BACKEND.lock();
         be.backing_buffer
@@ -361,6 +361,10 @@ fn tock<GS: GameState>(
             .unwrap()
             .default(be.gl.as_ref().unwrap());
         unsafe {
+            // And clear it
+            be.gl.as_ref().unwrap().clear_color(0.0, 0.0, 0.0, 1.0);
+            be.gl.as_ref().unwrap().clear(glow::COLOR_BUFFER_BIT);
+
             let bi = BACKEND_INTERNAL.lock();
             if bterm.post_scanlines {
                 bi.shaders[3].useProgram(be.gl.as_ref().unwrap());

--- a/bracket-terminal/src/hal/native/mainloop.rs
+++ b/bracket-terminal/src/hal/native/mainloop.rs
@@ -38,6 +38,8 @@ fn on_resize(
     INPUT.lock().set_scale_factor(dpi_scale_factor);
     let mut be = BACKEND.lock();
     be.screen_scaler.change_physical_size_smooth(physical_size.width, physical_size.height, dpi_scale_factor as f32, font_max_size);
+    let (l, r, t, b) = be.screen_scaler.get_backing_buffer_output_coordinates();
+    be.quad_vao = Some(setup_quad_gutter(be.gl.as_ref().unwrap(), l, r, t, b));
     if send_event {
         bterm.resize_pixels(
             physical_size.width as u32,
@@ -57,12 +59,12 @@ fn on_resize(
             )
         );
     }
-    let new_fb = Framebuffer::build_fbo(
+    /*let new_fb = Framebuffer::build_fbo(
         gl, 
         physical_size.width as i32, 
         physical_size.height as i32
     )?;
-    be.backing_buffer = Some(new_fb);
+    be.backing_buffer = Some(new_fb);*/
     bterm.on_event(BEvent::Resized {
         new_size: Point::new(be.screen_scaler.available_width, be.screen_scaler.available_height),
         dpi_scale_factor: dpi_scale_factor as f32,
@@ -70,6 +72,16 @@ fn on_resize(
 
     let mut bit = BACKEND_INTERNAL.lock();
     if be.resize_scaling && send_event {
+        // Framebuffer must be rebuilt because render target changed
+        let new_fb = Framebuffer::build_fbo(
+            gl,
+            be.screen_scaler.available_width as i32,
+            be.screen_scaler.available_height as i32
+        )?;
+        be.backing_buffer = Some(new_fb);
+        be.screen_scaler.logical_size.0 = be.screen_scaler.available_width;
+        be.screen_scaler.logical_size.1 = be.screen_scaler.available_height;
+
         let num_consoles = bit.consoles.len();
         for i in 0..num_consoles {
             let font_size = bit.fonts[bit.consoles[i].font_index].tile_size;
@@ -329,6 +341,9 @@ fn tock<GS: GameState>(
             .as_ref()
             .unwrap()
             .bind(be.gl.as_ref().unwrap());
+        unsafe {
+            be.gl.as_ref().unwrap().viewport(0, 0, be.screen_scaler.logical_size.0 as i32, be.screen_scaler.logical_size.1 as i32);
+        }
     }
 
     // Clear the backing buffer
@@ -361,7 +376,8 @@ fn tock<GS: GameState>(
             .unwrap()
             .default(be.gl.as_ref().unwrap());
         unsafe {
-            // And clear it
+            // And clear it, resetting the viewport
+            be.gl.as_ref().unwrap().viewport(0, 0, be.screen_scaler.physical_size.0 as i32, be.screen_scaler.physical_size.1 as i32);
             be.gl.as_ref().unwrap().clear_color(0.0, 0.0, 0.0, 1.0);
             be.gl.as_ref().unwrap().clear(glow::COLOR_BUFFER_BIT);
 

--- a/bracket-terminal/src/hal/webgpu/init.rs
+++ b/bracket-terminal/src/hal/webgpu/init.rs
@@ -57,8 +57,8 @@ pub fn init_raw<S: ToString>(
     let backing_buffer = Framebuffer::new(
         &device,
         surface.get_preferred_format(&adapter).unwrap(),
-        scaler.physical_size.0,
-        scaler.physical_size.1,
+        scaler.logical_size.0,
+        scaler.logical_size.1,
     );
 
     // Build a simple quad rendering VAO

--- a/bracket-terminal/src/hal/webgpu/quadrender.rs
+++ b/bracket-terminal/src/hal/webgpu/quadrender.rs
@@ -54,8 +54,12 @@ impl QuadRender {
         // Build the vertex buffer
         let mut quad_buffer = FloatBuffer::new(&[2, 2], 24, BufferUsages::VERTEX);
         quad_buffer.data = vec![
-            -1.0, 1.0, 0.0, 0.0, -1.0, -1.0, 0.0, 1.0, 1.0, -1.0, 1.0, 1.0, -1.0, 1.0, 0.0, 0.0,
-            1.0, -1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0,
+            -1.0, 1.0, 0.0, 0.0,
+            -1.0, -1.0, 0.0, 1.0,
+            1.0, -1.0, 1.0, 1.0,
+            -1.0, 1.0, 0.0, 0.0,
+            1.0, -1.0, 1.0, 1.0,
+            1.0, 1.0, 1.0, 0.0,
         ];
         quad_buffer.build(wgpu);
 
@@ -228,6 +232,18 @@ impl QuadRender {
         // submit will accept anything that implements IntoIter
         wgpu.queue.submit(std::iter::once(encoder.finish()));
         Ok(())
+    }
+
+    pub fn update_buffer_with_gutter(&mut self, wgpu: &WgpuLink, left: f32, right: f32, top: f32, bottom: f32) {
+        self.quad_buffer.data = vec![
+            left, top, 0.0, 0.0,
+            left, bottom ,0.0, 1.0,
+            right, bottom, 1.0, 1.0,
+            left, top, 0.0, 0.0,
+            right, bottom, 1.0, 1.0,
+            right, top, 1.0, 0.0,
+        ];
+        self.quad_buffer.build(wgpu);
     }
 }
 


### PR DESCRIPTION
Completely changes the approach to rendering with gutters and nice scaling.
The framebuffer is now always the *natural* size of the target. No scaling artifacts, and it looks good. FB only resizes when you are using auto-scaling consoles.
Framebuffer to screen uses linear filtering for a nicer scaling experience.
Should assist with: #226 #220 #213 #178 #171