### PR TITLE
#251 - Initialize screen_scaler for wasm backend

### DIFF
--- a/bracket-terminal/src/hal/wasm/init.rs
+++ b/bracket-terminal/src/hal/wasm/init.rs
@@ -5,7 +5,7 @@ pub fn init_raw<S: ToString>(
     width_pixels: u32,
     height_pixels: u32,
     _window_title: S,
-    _platform_hints: InitHints,
+    platform_hints: InitHints,
 ) -> BResult<BTerm> {
     use super::super::*;
     use super::*;
@@ -77,6 +77,7 @@ pub fn init_raw<S: ToString>(
     be.gl = Some(gl);
     be.quad_vao = Some(quad_vao);
     be.backing_buffer = Some(backing_fbo);
+    be.screen_scaler = ScreenScaler::new(platform_hints.desired_gutter, width_pixels, height_pixels);
 
     BACKEND_INTERNAL.lock().shaders = shaders;
 


### PR DESCRIPTION
FIXES #251 `screen_scaler` now properly initialized on WASM backend.

## Some extra context
Because `screen_scaler` is never initialized properly, `self.logical_size` is `(0, 0)`.

So when `calc_step` is called:
https://github.com/amethyst/bracket-lib/blob/4b475077ccf3bd67d196dfed94d4d719118934a2/bracket-terminal/src/hal/gl_common/backing/simple_console_backing.rs#L117

(which in turn executes)
https://github.com/amethyst/bracket-lib/blob/4b475077ccf3bd67d196dfed94d4d719118934a2/bracket-terminal/src/hal/scaler.rs#L213-L214

Here, we have a divide by zero.
https://github.com/amethyst/bracket-lib/blob/4b475077ccf3bd67d196dfed94d4d719118934a2/bracket-terminal/src/hal/scaler.rs#L196-L197

The result is `NaN` for `step_x` and `step_y`
