### PR TITLE
Derive Debug trait for enums used in fastnoise module

### DIFF
--- a/bracket-noise/src/fastnoise.rs
+++ b/bracket-noise/src/fastnoise.rs
@@ -5,7 +5,7 @@
 
 use bracket_random::prelude::RandomNumberGenerator;
 
-#[derive(PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 /// Type of noise to generate
 pub enum NoiseType {
     Value,
@@ -20,7 +20,7 @@ pub enum NoiseType {
     CubicFractal,
 }
 
-#[derive(PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 /// Interpolation function to use
 pub enum Interp {
     Linear,
@@ -28,7 +28,7 @@ pub enum Interp {
     Quintic,
 }
 
-#[derive(PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 /// Fractal function to use
 pub enum FractalType {
     FBM,
@@ -36,7 +36,7 @@ pub enum FractalType {
     RigidMulti,
 }
 
-#[derive(PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 /// Cellular noise distance function to use
 pub enum CellularDistanceFunction {
     Euclidean,
@@ -44,7 +44,7 @@ pub enum CellularDistanceFunction {
     Natural,
 }
 
-#[derive(PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 /// What type of cellular noise result do you want
 pub enum CellularReturnType {
     CellValue,


### PR DESCRIPTION
I have been building a small 'procedural map generation app' based on your awesome tutorial @thebracket. While working on allowing the user to configure the various 'map builders' I came across the issue that the `enum`s in the `bracket_noise` library do not implement the `Debug` trait so I went ahead and added `derive`s for them to be able to use these types in structs that want to derive Debug themselves.

I would be honored and happy if you accepted the PR. Thanks for the great content you are producing - both your RLTK tutorial and the book are awesome and inspiring, keep up the good work!