### PR TITLE
Added ability for the user to enable or disable the mouse cursor when using the native gl backend

### DIFF
--- a/bracket-terminal/src/bterm.rs
+++ b/bracket-terminal/src/bterm.rs
@@ -78,6 +78,7 @@ pub struct BTerm {
     pub post_scanlines: bool,
     pub post_screenburn: bool,
     pub screen_burn_color: bracket_color::prelude::RGB,
+    pub mouse_visible: bool,
 }
 
 impl BTerm {
@@ -327,6 +328,11 @@ impl BTerm {
     // Change the screen-burn color
     pub fn screen_burn_color(&mut self, color: bracket_color::prelude::RGB) {
         self.screen_burn_color = color;
+    }
+
+    // Set the mouse cursor visibility
+    pub fn with_mouse_visibility(&mut self, with_visibility: bool) {
+        self.mouse_visible = with_visibility;
     }
 
     /// Internal: mark a key press

--- a/bracket-terminal/src/hal/crossterm_be/init.rs
+++ b/bracket-terminal/src/hal/crossterm_be/init.rs
@@ -47,6 +47,7 @@ pub fn init_raw<S: ToString>(
         post_scanlines: false,
         post_screenburn: false,
         screen_burn_color: bracket_color::prelude::RGB::from_f32(0.0, 1.0, 1.0),
+        mouse_visible: true,
     };
     Ok(bterm)
 }

--- a/bracket-terminal/src/hal/curses/init.rs
+++ b/bracket-terminal/src/hal/curses/init.rs
@@ -57,6 +57,7 @@ pub fn init_raw<S: ToString>(
         post_scanlines: false,
         post_screenburn: false,
         screen_burn_color: bracket_color::prelude::RGB::from_f32(0.0, 1.0, 1.0),
+        mouse_visible: true,
     };
     Ok(bterm)
 }

--- a/bracket-terminal/src/hal/native/init.rs
+++ b/bracket-terminal/src/hal/native/init.rs
@@ -130,6 +130,7 @@ pub fn init_raw<S: ToString>(
         post_scanlines: false,
         post_screenburn: false,
         screen_burn_color: bracket_color::prelude::RGB::from_f32(0.0, 1.0, 1.0),
+        mouse_visible: true,
     };
     Ok(bterm)
 }

--- a/bracket-terminal/src/hal/native/mainloop.rs
+++ b/bracket-terminal/src/hal/native/mainloop.rs
@@ -148,6 +148,8 @@ pub fn main_loop<GS: GameState>(mut bterm: BTerm, mut gamestate: GS) -> BResult<
             *control_flow = ControlFlow::Exit;
         }
 
+        wc.window().set_cursor_visible(bterm.mouse_visible);
+
         match &event {
             Event::RedrawEventsCleared => {
                 let frame_timer = Instant::now();

--- a/bracket-terminal/src/hal/wasm/init.rs
+++ b/bracket-terminal/src/hal/wasm/init.rs
@@ -100,5 +100,6 @@ pub fn init_raw<S: ToString>(
         post_scanlines: false,
         post_screenburn: false,
         screen_burn_color: bracket_color::prelude::RGB::from_f32(0.0, 1.0, 1.0),
+        mouse_visible: true
     })
 }

--- a/bracket-terminal/src/hal/webgpu/init.rs
+++ b/bracket-terminal/src/hal/webgpu/init.rs
@@ -99,6 +99,7 @@ pub fn init_raw<S: ToString>(
         post_scanlines: false,
         post_screenburn: false,
         screen_burn_color: bracket_color::prelude::RGB::from_f32(0.0, 1.0, 1.0),
+        mouse_visible: true,
     };
     Ok(bterm)
 }


### PR DESCRIPTION
I added the ability to set the mouse cursor visibility on opengl so the user can do things like build a software cursor. The user can change the visibility by either manually setting a bool in the BTerm context called mouse_visibility or by using `ctx.with_mouse_visibility(false);`. I wasn't able to figure out how to get it to work on wgpu or crossterm as the library won't compile on my system when using those backends. I don't think it's possible to set the cursor visibility on curses, so on backends other than native gl the variable and the function do nothing.

![image](https://user-images.githubusercontent.com/3222988/166089442-fd3c0211-269a-48e0-8b71-fcc7959c575e.png)
