### PR TITLE
Use g value instead of f value to create sucessors in A*

### DIFF
--- a/bracket-pathfinding/src/astar.rs
+++ b/bracket-pathfinding/src/astar.rs
@@ -105,17 +105,17 @@ impl AStar {
 
     /// Adds a successor; if we're at the end, marks success.
     fn add_successor(&mut self, q: Node, idx: usize, cost: f32, map: &dyn BaseMap) {
-        let distance = self.distance_to_end(idx, map);
+        let distance_to_end = self.distance_to_end(idx, map);
         let s = Node {
             idx,
-            f: distance + cost,
-            g: cost,
+            f: q.g + cost + distance_to_end,
+            g: q.g + cost,
         };
 
         // If a node with the same position as successor is in the open list with a lower f, skip add
         let mut should_add = true;
         if let Some(e) = self.parents.get(&idx) {
-            if e.1 < s.f {
+            if e.1 < s.g {
                 should_add = false;
             }
         }
@@ -127,7 +127,7 @@ impl AStar {
 
         if should_add {
             self.open_list.push(s);
-            self.parents.insert(idx, (q.idx, q.f));
+            self.parents.insert(idx, (q.idx, s.g));
         }
     }
 
@@ -164,7 +164,7 @@ impl AStar {
             // Generate successors
             map.get_available_exits(q.idx)
                 .iter()
-                .for_each(|s| self.add_successor(q, s.0, s.1 + q.f, map));
+                .for_each(|s| self.add_successor(q, s.0, s.1, map));
 
             if self.closed_list.contains_key(&q.idx) {
                 self.closed_list.remove(&q.idx);


### PR DESCRIPTION
This pull request fixes an error in the A* implementation and adds two separate test cases to prevent the issue I was facing in the future.

Fixes #267 

# Details

The A* implementation previously used these formulas to calculate the new g and f values for a node:
```
successor.g = previous.f + step_cost
successor.f = previous.f + step_cost + distance_to_end
```
The correct equations however use the `previous.g` value instead. See [here](https://en.wikipedia.org/wiki/A*_search_algorithm#Pseudocode), [here](https://gist.github.com/jcward/45afd22560939aaae5c75e68f1e57505#summary-of-the-a-method), or [here](https://www.redblobgames.com/pathfinding/a-star/implementation.html#cpp-astar) for reference.

`g` is the cost to reach the node from the start, `f` is `g` plus a heuristic for the remaining cost to reach the destination.
Using the cost + heuristic to calculate the cost for the next node does not make sense, the new `f` value would then contain the heuristic for the distance between the two nodes twice, resulting in a value that increases with the number of nodes in a path instead of the distance. This is why I added the more generic testcase.

I also changed the way the cost is passed to the `add_successor` function. Instead of passing `q.g + step_cost`, now only the step cost is passed. This is because q (and thus also q.g) is already passed to the function and the I think the new cost should conceptually be calculated inside `add_successor` instead of the call-site.