### PR TITLE
check if window is active before processing

### DIFF
--- a/bracket-bevy/src/consoles/update_system.rs
+++ b/bracket-bevy/src/consoles/update_system.rs
@@ -104,9 +104,15 @@ pub(crate) fn update_mouse_position(
     // Bevy really needs a nicer way to do this
     let (camera, camera_transform) = q_camera.single();
     let wnd = if let RenderTarget::Window(id) = camera.target {
-        wnds.get(id).unwrap()
+        wnds.get(id)
     } else {
-        wnds.get_primary().unwrap()
+        wnds.get_primary()
+    };
+
+    let wnd = if let Some(wnd) = wnd {
+        wnd
+    } else {
+        return;
     };
 
     if let Some(screen_pos) = wnd.cursor_position() {


### PR DESCRIPTION
Whenever the window is closed, or the close_on_exit system is used, bevy closes all windows then sends the `AppExit` event to shutdown the application. During that time, the systems still run, like our mouse_update system which causes errors on unwrapping of the current window. This just adds a check to see if the window exist.

This is my first ever PR to another repo so I don't really know how to structure this or if I even did a decent job (rust noob here) so any feedback is welcome!