### PR TITLE
move width/height attributes to i32

### DIFF
--- a/bracket-bevy/examples/tiles.rs
+++ b/bracket-bevy/examples/tiles.rs
@@ -2,8 +2,8 @@ use bevy::prelude::*;
 use bracket_bevy::prelude::*;
 use bracket_pathfinding::prelude::*;
 
-const WIDTH: usize = 40;
-const HEIGHT: usize = 25;
+const WIDTH: i32 = 40;
+const HEIGHT: i32 = 25;
 
 #[derive(PartialEq, Copy, Clone)]
 enum TileType {

--- a/bracket-bevy/src/builder/bterm_builder.rs
+++ b/bracket-bevy/src/builder/bterm_builder.rs
@@ -153,7 +153,7 @@ impl BTermBuilder {
         self
     }
 
-    pub fn with_simple_console(mut self, font_index: usize, width: usize, height: usize) -> Self {
+    pub fn with_simple_console(mut self, font_index: usize, width: i32, height: i32) -> Self {
         self.layers.push(TerminalLayer::Simple {
             font_index,
             width,
@@ -163,7 +163,7 @@ impl BTermBuilder {
         self
     }
 
-    pub fn with_sparse_console(mut self, font_index: usize, width: usize, height: usize) -> Self {
+    pub fn with_sparse_console(mut self, font_index: usize, width: i32, height: i32) -> Self {
         self.layers.push(TerminalLayer::Sparse {
             font_index,
             width,

--- a/bracket-bevy/src/builder/terminal_layer.rs
+++ b/bracket-bevy/src/builder/terminal_layer.rs
@@ -4,14 +4,14 @@ use std::collections::HashSet;
 pub enum TerminalLayer {
     Simple {
         font_index: usize,
-        width: usize,
-        height: usize,
+        width: i32,
+        height: i32,
         features: HashSet<SimpleConsoleFeatures>,
     },
     Sparse {
         font_index: usize,
-        width: usize,
-        height: usize,
+        width: i32,
+        height: i32,
         features: HashSet<SparseConsoleFeatures>,
     },
 }

--- a/bracket-bevy/src/consoles/mod.rs
+++ b/bracket-bevy/src/consoles/mod.rs
@@ -19,7 +19,7 @@ mod draw_batch;
 pub use draw_batch::*;
 
 pub(crate) trait ConsoleFrontEnd: Sync + Send {
-    fn get_char_size(&self) -> (usize, usize);
+    fn get_char_size(&self) -> (i32, i32);
     fn get_pixel_size(&self) -> (f32, f32);
     fn at(&self, x: i32, y: i32) -> usize;
     fn get_clipping(&self) -> Option<Rect>;
@@ -37,25 +37,9 @@ pub(crate) trait ConsoleFrontEnd: Sync + Send {
     fn set(&mut self, x: i32, y: i32, fg: RGBA, bg: RGBA, glyph: u16);
     fn set_bg(&mut self, x: i32, y: i32, bg: RGBA);
     fn draw_box(&mut self, x: i32, y: i32, width: i32, height: i32, fg: RGBA, bg: RGBA);
-    fn draw_hollow_box(
-        &mut self,
-        x: i32,
-        y: i32,
-        width: i32,
-        height: i32,
-        fg: RGBA,
-        bg: RGBA,
-    );
+    fn draw_hollow_box(&mut self, x: i32, y: i32, width: i32, height: i32, fg: RGBA, bg: RGBA);
 
-    fn draw_box_double(
-        &mut self,
-        x: i32,
-        y: i32,
-        width: i32,
-        height: i32,
-        fg: RGBA,
-        bg: RGBA,
-    );
+    fn draw_box_double(&mut self, x: i32, y: i32, width: i32, height: i32, fg: RGBA, bg: RGBA);
 
     fn draw_hollow_box_double(
         &mut self,
@@ -146,7 +130,7 @@ pub(crate) trait ConsoleFrontEnd: Sync + Send {
     fn get_font_index(&self) -> usize;
 }
 
-#[derive(PartialEq, Copy, Clone, Debug)]
+#[derive(Eq, PartialEq, Copy, Clone, Debug)]
 pub enum TextAlign {
     Left,
     Center,

--- a/bracket-bevy/src/consoles/scaler.rs
+++ b/bracket-bevy/src/consoles/scaler.rs
@@ -88,7 +88,7 @@ impl ScreenScaler {
         )
     }
 
-    pub(crate) fn calc_step(&self, width: usize, height: usize) -> (f32, f32) {
+    pub(crate) fn calc_step(&self, width: i32, height: i32) -> (f32, f32) {
         (
             (self.screen.0 - self.x_gutter as f32) / width as f32,
             (self.screen.1 - self.y_gutter as f32) / height as f32,
@@ -102,17 +102,17 @@ impl ScreenScaler {
     pub(crate) fn calc_mouse_position(
         &self,
         pos: (f32, f32),
-        width: usize,
-        height: usize,
-    ) -> (usize, usize) {
+        width: i32,
+        height: i32,
+    ) -> (i32, i32) {
         let step = self.calc_step(width, height);
         let step_pos = (
             (pos.0 / step.0) + (width as f32 / 2.0),
             (pos.1 / step.1) + (height as f32 / 2.0),
         );
         (
-            usize::clamp(step_pos.0 as usize, 0, width - 1),
-            usize::clamp(height - step_pos.1 as usize, 0, height - 1),
+            i32::clamp(step_pos.0 as i32, 0, width - 1),
+            i32::clamp(height - step_pos.1 as i32, 0, height - 1),
         )
     }
 }

--- a/bracket-bevy/src/consoles/simple_console/back_end/mod.rs
+++ b/bracket-bevy/src/consoles/simple_console/back_end/mod.rs
@@ -19,5 +19,5 @@ pub(crate) trait SimpleConsoleBackend: Sync + Send {
     ) -> Handle<Mesh>;
     fn spawn(&self, commands: &mut Commands, material: Handle<ColorMaterial>, idx: usize);
     fn get_pixel_size(&self) -> (f32, f32);
-    fn resize(&mut self, available_size: &(f32, f32)) -> (usize, usize);
+    fn resize(&mut self, available_size: &(f32, f32)) -> (i32, i32);
 }

--- a/bracket-bevy/src/consoles/simple_console/back_end/simple_no_background.rs
+++ b/bracket-bevy/src/consoles/simple_console/back_end/simple_no_background.rs
@@ -9,8 +9,8 @@ use bevy::{
 pub(crate) struct SimpleBackendNoBackground {
     pub(crate) mesh_handle: Option<Handle<Mesh>>,
     pub(crate) font_height_pixels: (f32, f32),
-    pub(crate) width: usize,
-    pub(crate) height: usize,
+    pub(crate) width: i32,
+    pub(crate) height: i32,
     pub(crate) scaler: FontScaler,
 }
 
@@ -21,8 +21,8 @@ impl SimpleBackendNoBackground {
         chars_per_row: u16,
         n_rows: u16,
         font_height_pixels: (f32, f32),
-        width: usize,
-        height: usize,
+        width: i32,
+        height: i32,
     ) -> Self {
         let mut back_end = Self {
             mesh_handle: None,
@@ -38,11 +38,13 @@ impl SimpleBackendNoBackground {
     }
 
     pub fn build_mesh(&self, parent: &SimpleConsole, screen_scaler: &ScreenScaler) -> Mesh {
-        let mut vertices: Vec<[f32; 3]> = Vec::with_capacity(self.width * self.height * 4);
-        let mut normals: Vec<[f32; 3]> = Vec::with_capacity(self.width * self.height * 4);
-        let mut uv: Vec<[f32; 2]> = Vec::with_capacity(self.width * self.height * 4);
-        let mut colors: Vec<[f32; 4]> = Vec::with_capacity(self.width * self.height * 4);
-        let mut indices: Vec<u32> = Vec::with_capacity(self.width * self.height * 6);
+        let mut vertices: Vec<[f32; 3]> =
+            Vec::with_capacity((self.width * self.height * 4) as usize);
+        let mut normals: Vec<[f32; 3]> =
+            Vec::with_capacity((self.width * self.height * 4) as usize);
+        let mut uv: Vec<[f32; 2]> = Vec::with_capacity((self.width * self.height * 4) as usize);
+        let mut colors: Vec<[f32; 4]> = Vec::with_capacity((self.width * self.height * 4) as usize);
+        let mut indices: Vec<u32> = Vec::with_capacity((self.width * self.height * 6) as usize);
         let mut index_count = 0;
         let scale = screen_scaler.calc_step(self.width, self.height);
         let top_left = screen_scaler.top_left();
@@ -50,7 +52,7 @@ impl SimpleBackendNoBackground {
         // Build the foreground
         for y in 0..self.height {
             let screen_y = top_left.1 + (y as f32 * scale.1);
-            let mut idx = (self.height - 1 - y) * self.width;
+            let mut idx = ((self.height - 1 - y) * self.width) as usize;
             for x in 0..self.width {
                 let screen_x = top_left.0 + (x as f32 * scale.0);
                 vertices.push([screen_x, screen_y, 0.5]);
@@ -120,9 +122,9 @@ impl SimpleConsoleBackend for SimpleBackendNoBackground {
         self.font_height_pixels
     }
 
-    fn resize(&mut self, available_size: &(f32, f32)) -> (usize, usize) {
-        self.width = (available_size.0 / self.font_height_pixels.0).floor() as usize;
-        self.height = (available_size.1 / self.font_height_pixels.1).floor() as usize;
+    fn resize(&mut self, available_size: &(f32, f32)) -> (i32, i32) {
+        self.width = (available_size.0 / self.font_height_pixels.0).floor() as i32;
+        self.height = (available_size.1 / self.font_height_pixels.1).floor() as i32;
 
         (self.width, self.height)
     }

--- a/bracket-bevy/src/consoles/simple_console/back_end/simple_with_background.rs
+++ b/bracket-bevy/src/consoles/simple_console/back_end/simple_with_background.rs
@@ -10,8 +10,8 @@ use super::SimpleConsoleBackend;
 pub(crate) struct SimpleBackendWithBackground {
     pub(crate) mesh_handle: Option<Handle<Mesh>>,
     pub(crate) font_height_pixels: (f32, f32),
-    pub(crate) width: usize,
-    pub(crate) height: usize,
+    pub(crate) width: i32,
+    pub(crate) height: i32,
     pub(crate) scaler: FontScaler,
 }
 
@@ -22,8 +22,8 @@ impl SimpleBackendWithBackground {
         chars_per_row: u16,
         n_rows: u16,
         font_height_pixels: (f32, f32),
-        width: usize,
-        height: usize,
+        width: i32,
+        height: i32,
     ) -> Self {
         let mut back_end = Self {
             mesh_handle: None,
@@ -39,11 +39,13 @@ impl SimpleBackendWithBackground {
     }
 
     pub fn build_mesh(&self, parent: &SimpleConsole, screen_scaler: &ScreenScaler) -> Mesh {
-        let mut vertices: Vec<[f32; 3]> = Vec::with_capacity(self.width * self.height * 8);
-        let mut normals: Vec<[f32; 3]> = Vec::with_capacity(self.width * self.height * 8);
-        let mut uv: Vec<[f32; 2]> = Vec::with_capacity(self.width * self.height * 8);
-        let mut colors: Vec<[f32; 4]> = Vec::with_capacity(self.width * self.height * 8);
-        let mut indices: Vec<u32> = Vec::with_capacity(self.width * self.height * 12);
+        let mut vertices: Vec<[f32; 3]> =
+            Vec::with_capacity((self.width * self.height * 8) as usize);
+        let mut normals: Vec<[f32; 3]> =
+            Vec::with_capacity((self.width * self.height * 8) as usize);
+        let mut uv: Vec<[f32; 2]> = Vec::with_capacity((self.width * self.height * 8) as usize);
+        let mut colors: Vec<[f32; 4]> = Vec::with_capacity((self.width * self.height * 8) as usize);
+        let mut indices: Vec<u32> = Vec::with_capacity((self.width * self.height * 12) as usize);
         let mut index_count = 0;
         let scale = screen_scaler.calc_step(self.width, self.height);
         let top_left = screen_scaler.top_left();
@@ -51,7 +53,7 @@ impl SimpleBackendWithBackground {
         // Build the background
         for y in 0..self.height {
             let screen_y = top_left.1 + (y as f32 * scale.1);
-            let mut idx = y * self.width;
+            let mut idx = (y * self.width) as usize;
             for x in 0..self.width {
                 let screen_x = top_left.0 + (x as f32 * scale.0);
                 vertices.push([screen_x, screen_y, 0.0]);
@@ -88,7 +90,7 @@ impl SimpleBackendWithBackground {
         // Build the foreground
         for y in 0..self.height {
             let screen_y = top_left.1 + (y as f32 * scale.1);
-            let mut idx = y * self.width;
+            let mut idx = (y * self.width) as usize;
             for x in 0..self.width {
                 let screen_x = top_left.0 + (x as f32 * scale.0);
                 vertices.push([screen_x, screen_y, 0.5]);
@@ -158,9 +160,9 @@ impl SimpleConsoleBackend for SimpleBackendWithBackground {
         self.font_height_pixels
     }
 
-    fn resize(&mut self, available_size: &(f32, f32)) -> (usize, usize) {
-        self.width = (available_size.0 / self.font_height_pixels.0).floor() as usize;
-        self.height = (available_size.1 / self.font_height_pixels.1).floor() as usize;
+    fn resize(&mut self, available_size: &(f32, f32)) -> (i32, i32) {
+        self.width = (available_size.0 / self.font_height_pixels.0).floor() as i32;
+        self.height = (available_size.1 / self.font_height_pixels.1).floor() as i32;
 
         (self.width, self.height)
     }

--- a/bracket-bevy/src/consoles/simple_console/front_end.rs
+++ b/bracket-bevy/src/consoles/simple_console/front_end.rs
@@ -17,21 +17,21 @@ use std::collections::HashSet;
 
 pub(crate) struct SimpleConsole {
     pub(crate) font_index: usize,
-    pub(crate) width: usize,
-    pub(crate) height: usize,
+    pub(crate) width: i32,
+    pub(crate) height: i32,
     pub(crate) terminal: Vec<TerminalGlyph>,
     back_end: Option<Box<dyn SimpleConsoleBackend>>,
     clipping: Option<Rect>,
-    mouse_chars: (usize, usize),
+    mouse_chars: (i32, i32),
 }
 
 impl SimpleConsole {
-    pub fn new(font_index: usize, width: usize, height: usize) -> Self {
+    pub fn new(font_index: usize, width: i32, height: i32) -> Self {
         Self {
             font_index,
             width,
             height,
-            terminal: vec![TerminalGlyph::default(); width * height],
+            terminal: vec![TerminalGlyph::default(); (width * height) as usize],
             back_end: None,
             clipping: None,
             mouse_chars: (0, 0),
@@ -90,7 +90,7 @@ impl SimpleConsole {
 }
 
 impl ConsoleFrontEnd for SimpleConsole {
-    fn get_char_size(&self) -> (usize, usize) {
+    fn get_char_size(&self) -> (i32, i32) {
         (self.width, self.height)
     }
 
@@ -166,7 +166,11 @@ impl ConsoleFrontEnd for SimpleConsole {
     }
 
     fn print_centered(&mut self, y: i32, text: &str) {
-        self.print((self.width as i32 / 2) - (text.to_string().len() as i32 / 2), y, text);
+        self.print(
+            (self.width as i32 / 2) - (text.to_string().len() as i32 / 2),
+            y,
+            text,
+        );
     }
 
     fn print_centered_at(&mut self, x: i32, y: i32, text: &str) {
@@ -203,27 +207,11 @@ impl ConsoleFrontEnd for SimpleConsole {
         common_draw::draw_box(self, sx, sy, width, height, fg, bg);
     }
 
-    fn draw_hollow_box(
-        &mut self,
-        x: i32,
-        y: i32,
-        width: i32,
-        height: i32,
-        fg: RGBA,
-        bg: RGBA,
-    ) {
+    fn draw_hollow_box(&mut self, x: i32, y: i32, width: i32, height: i32, fg: RGBA, bg: RGBA) {
         common_draw::draw_hollow_box(self, x, y, width, height, fg, bg);
     }
 
-    fn draw_box_double(
-        &mut self,
-        x: i32,
-        y: i32,
-        width: i32,
-        height: i32,
-        fg: RGBA,
-        bg: RGBA,
-    ) {
+    fn draw_box_double(&mut self, x: i32, y: i32, width: i32, height: i32, fg: RGBA, bg: RGBA) {
         common_draw::draw_box_double(self, x, y, width, height, fg, bg);
     }
 
@@ -306,7 +294,7 @@ impl ConsoleFrontEnd for SimpleConsole {
             let (w, h) = back_end.resize(available_size);
             self.width = w;
             self.height = h;
-            self.terminal = vec![TerminalGlyph::default(); w * h];
+            self.terminal = vec![TerminalGlyph::default(); (w * h) as usize];
         }
     }
 

--- a/bracket-bevy/src/consoles/sparse_console/back_end/mod.rs
+++ b/bracket-bevy/src/consoles/sparse_console/back_end/mod.rs
@@ -19,5 +19,5 @@ pub(crate) trait SparseConsoleBackend: Sync + Send {
     ) -> Handle<Mesh>;
     fn spawn(&self, commands: &mut Commands, material: Handle<ColorMaterial>, idx: usize);
     fn get_pixel_size(&self) -> (f32, f32);
-    fn resize(&mut self, available_size: &(f32, f32)) -> (usize, usize);
+    fn resize(&mut self, available_size: &(f32, f32)) -> (i32, i32);
 }

--- a/bracket-bevy/src/consoles/sparse_console/back_end/sparse_no_background.rs
+++ b/bracket-bevy/src/consoles/sparse_console/back_end/sparse_no_background.rs
@@ -9,8 +9,8 @@ use bevy::{
 pub(crate) struct SparseBackendNoBackground {
     pub(crate) mesh_handle: Option<Handle<Mesh>>,
     pub(crate) font_height_pixels: (f32, f32),
-    pub(crate) width: usize,
-    pub(crate) height: usize,
+    pub(crate) width: i32,
+    pub(crate) height: i32,
     pub(crate) scaler: FontScaler,
 }
 
@@ -21,8 +21,8 @@ impl SparseBackendNoBackground {
         chars_per_row: u16,
         n_rows: u16,
         font_height_pixels: (f32, f32),
-        width: usize,
-        height: usize,
+        width: i32,
+        height: i32,
     ) -> Self {
         let mut back_end = Self {
             mesh_handle: None,
@@ -120,9 +120,9 @@ impl SparseConsoleBackend for SparseBackendNoBackground {
         self.font_height_pixels
     }
 
-    fn resize(&mut self, available_size: &(f32, f32)) -> (usize, usize) {
-        self.width = (available_size.0 / self.font_height_pixels.0).floor() as usize;
-        self.height = (available_size.1 / self.font_height_pixels.1).floor() as usize;
+    fn resize(&mut self, available_size: &(f32, f32)) -> (i32, i32) {
+        self.width = (available_size.0 / self.font_height_pixels.0).floor() as i32;
+        self.height = (available_size.1 / self.font_height_pixels.1).floor() as i32;
 
         (self.width, self.height)
     }

--- a/bracket-bevy/src/consoles/sparse_console/back_end/sparse_with_background.rs
+++ b/bracket-bevy/src/consoles/sparse_console/back_end/sparse_with_background.rs
@@ -9,8 +9,8 @@ use bevy::{
 pub(crate) struct SparseBackendWithBackground {
     pub(crate) mesh_handle: Option<Handle<Mesh>>,
     pub(crate) font_height_pixels: (f32, f32),
-    pub(crate) width: usize,
-    pub(crate) height: usize,
+    pub(crate) width: i32,
+    pub(crate) height: i32,
     pub(crate) scaler: FontScaler,
 }
 
@@ -21,8 +21,8 @@ impl SparseBackendWithBackground {
         chars_per_row: u16,
         n_rows: u16,
         font_height_pixels: (f32, f32),
-        width: usize,
-        height: usize,
+        width: i32,
+        height: i32,
     ) -> Self {
         let mut back_end = Self {
             mesh_handle: None,
@@ -151,9 +151,9 @@ impl SparseConsoleBackend for SparseBackendWithBackground {
         self.font_height_pixels
     }
 
-    fn resize(&mut self, available_size: &(f32, f32)) -> (usize, usize) {
-        self.width = (available_size.0 / self.font_height_pixels.0).floor() as usize;
-        self.height = (available_size.1 / self.font_height_pixels.1).floor() as usize;
+    fn resize(&mut self, available_size: &(f32, f32)) -> (i32, i32) {
+        self.width = (available_size.0 / self.font_height_pixels.0).floor() as i32;
+        self.height = (available_size.1 / self.font_height_pixels.1).floor() as i32;
 
         (self.width, self.height)
     }

--- a/bracket-bevy/src/consoles/sparse_console/front_end.rs
+++ b/bracket-bevy/src/consoles/sparse_console/front_end.rs
@@ -15,16 +15,16 @@ use bracket_geometry::prelude::Point;
 
 pub(crate) struct SparseConsole {
     pub(crate) font_index: usize,
-    pub(crate) width: usize,
-    pub(crate) height: usize,
+    pub(crate) width: i32,
+    pub(crate) height: i32,
     pub(crate) terminal: Vec<(i32, i32, TerminalGlyph)>,
     back_end: Option<Box<dyn SparseConsoleBackend>>,
     clipping: Option<Rect>,
-    mouse_chars: (usize, usize),
+    mouse_chars: (i32, i32),
 }
 
 impl SparseConsole {
-    pub fn new(font_index: usize, width: usize, height: usize) -> Self {
+    pub fn new(font_index: usize, width: i32, height: i32) -> Self {
         Self {
             font_index,
             width,
@@ -80,7 +80,7 @@ impl SparseConsole {
 }
 
 impl ConsoleFrontEnd for SparseConsole {
-    fn get_char_size(&self) -> (usize, usize) {
+    fn get_char_size(&self) -> (i32, i32) {
         (self.width, self.height)
     }
 
@@ -162,7 +162,11 @@ impl ConsoleFrontEnd for SparseConsole {
     }
 
     fn print_centered(&mut self, y: i32, text: &str) {
-        self.print((self.width as i32 / 2) - (text.to_string().len() as i32 / 2), y, text);
+        self.print(
+            (self.width as i32 / 2) - (text.to_string().len() as i32 / 2),
+            y,
+            text,
+        );
     }
 
     fn print_centered_at(&mut self, x: i32, y: i32, text: &str) {
@@ -199,27 +203,11 @@ impl ConsoleFrontEnd for SparseConsole {
         common_draw::draw_box(self, sx, sy, width, height, fg, bg);
     }
 
-    fn draw_hollow_box(
-        &mut self,
-        x: i32,
-        y: i32,
-        width: i32,
-        height: i32,
-        fg: RGBA,
-        bg: RGBA,
-    ) {
+    fn draw_hollow_box(&mut self, x: i32, y: i32, width: i32, height: i32, fg: RGBA, bg: RGBA) {
         common_draw::draw_hollow_box(self, x, y, width, height, fg, bg);
     }
 
-    fn draw_box_double(
-        &mut self,
-        x: i32,
-        y: i32,
-        width: i32,
-        height: i32,
-        fg: RGBA,
-        bg: RGBA,
-    ) {
+    fn draw_box_double(&mut self, x: i32, y: i32, width: i32, height: i32, fg: RGBA, bg: RGBA) {
         common_draw::draw_box_double(self, x, y, width, height, fg, bg);
     }
 

--- a/bracket-bevy/src/consoles/virtual_console.rs
+++ b/bracket-bevy/src/consoles/virtual_console.rs
@@ -5,8 +5,8 @@ use super::{common_draw, ConsoleFrontEnd, TerminalGlyph};
 use crate::BracketContext;
 
 pub struct VirtualConsole {
-    pub width: usize,
-    pub height: usize,
+    pub width: i32,
+    pub height: i32,
     pub terminal: Vec<TerminalGlyph>,
     pub clipping: Option<Rect>,
 }
@@ -16,8 +16,8 @@ impl VirtualConsole {
     pub fn new(dimensions: Point) -> Self {
         let num_tiles: usize = (dimensions.x * dimensions.y) as usize;
         let mut console = VirtualConsole {
-            width: dimensions.x as usize,
-            height: dimensions.y as usize,
+            width: dimensions.x,
+            height: dimensions.y,
             terminal: Vec::with_capacity(num_tiles),
             clipping: None,
         };
@@ -29,7 +29,7 @@ impl VirtualConsole {
 
     /// Creates a new virtual console from a blob of text.
     /// Useful if you want to scroll through manuals!
-    pub fn from_text(text: &str, width: usize) -> Self {
+    pub fn from_text(text: &str, width: i32) -> Self {
         let raw_lines = text.split('\n');
         let mut lines: Vec<String> = Vec::new();
         for line in raw_lines {
@@ -37,7 +37,7 @@ impl VirtualConsole {
 
             line.chars().for_each(|c| {
                 newline.push(c);
-                if newline.len() > width {
+                if newline.len() > width as usize {
                     lines.push(newline.clone());
                     newline.clear();
                 }
@@ -45,10 +45,10 @@ impl VirtualConsole {
             lines.push(newline.clone());
         }
 
-        let num_tiles: usize = width * lines.len();
+        let num_tiles: usize = width as usize * lines.len();
         let mut console = VirtualConsole {
             width,
-            height: lines.len(),
+            height: lines.len() as i32,
             terminal: Vec::with_capacity(num_tiles),
             clipping: None,
         };
@@ -84,13 +84,7 @@ impl VirtualConsole {
                 if let Some(idx) = self.try_at(source_x, source_y) {
                     let t = self.terminal[idx];
                     if t.glyph > 0 {
-                        target.set(
-                            x,
-                            y,
-                            t.foreground.into(),
-                            t.background.into(),
-                            t.glyph,
-                        );
+                        target.set(x, y, t.foreground.into(), t.background.into(), t.glyph);
                     }
                 }
             }
@@ -108,7 +102,7 @@ impl VirtualConsole {
 }
 
 impl ConsoleFrontEnd for VirtualConsole {
-    fn get_char_size(&self) -> (usize, usize) {
+    fn get_char_size(&self) -> (i32, i32) {
         (self.width, self.height)
     }
 
@@ -175,7 +169,11 @@ impl ConsoleFrontEnd for VirtualConsole {
     }
 
     fn print_centered(&mut self, y: i32, text: &str) {
-        self.print((self.width as i32 / 2) - (text.to_string().len() / 2) as i32, y, text);
+        self.print(
+            (self.width as i32 / 2) - (text.to_string().len() / 2) as i32,
+            y,
+            text,
+        );
     }
 
     fn print_centered_at(&mut self, x: i32, y: i32, text: &str) {
@@ -212,27 +210,11 @@ impl ConsoleFrontEnd for VirtualConsole {
         common_draw::draw_box(self, sx, sy, width, height, fg, bg);
     }
 
-    fn draw_hollow_box(
-        &mut self,
-        x: i32,
-        y: i32,
-        width: i32,
-        height: i32,
-        fg: RGBA,
-        bg: RGBA,
-    ) {
+    fn draw_hollow_box(&mut self, x: i32, y: i32, width: i32, height: i32, fg: RGBA, bg: RGBA) {
         common_draw::draw_hollow_box(self, x, y, width, height, fg, bg);
     }
 
-    fn draw_box_double(
-        &mut self,
-        x: i32,
-        y: i32,
-        width: i32,
-        height: i32,
-        fg: RGBA,
-        bg: RGBA,
-    ) {
+    fn draw_box_double(&mut self, x: i32, y: i32, width: i32, height: i32, fg: RGBA, bg: RGBA) {
         common_draw::draw_box_double(self, x, y, width, height, fg, bg);
     }
 


### PR DESCRIPTION
I tested on the tiles example and also dwarf map. The mouse coordinates are off by what seems 1-1. This doesn't seem to be a reflection of moving to i32 since it is also happening on the base with usize.

Resizing doesnt explode now :).

Edit:

seems like my rustfmt touched some files by reformatting some things. Sorry about that :/

https://user-images.githubusercontent.com/9278174/173622137-a8c2add5-bf0c-4e7d-b03a-3bbc442d3098.mp4


