### PR TITLE
bump wgpu to v13.1; Add Bracket Systems to correct stages

### DIFF
--- a/bracket-bevy/Cargo.toml
+++ b/bracket-bevy/Cargo.toml
@@ -15,12 +15,12 @@ license = "MIT"
 [dependencies]
 # Using my version until my PR for colored vertex support is (hopefully) merged.
 bevy = { git = "https://github.com/bevyengine/bevy.git" }
-parking_lot = "0.11"
+parking_lot = "0.12.1"
 lazy_static = "1.4"
 bracket-random = { path = "../bracket-random" }
 bracket-color = { path = "../bracket-color", features = [ "bevy" ] }
 bracket-geometry = { path = "../bracket-geometry", version = "~0.8.3" }
 
 [dev-dependencies]
-bracket-pathfinding = { path = "../bracket-pathfinding", version = "~0.8.4" }
+bracket-pathfinding = { path = "../bracket-pathfinding", version = "~0.8.5" }
 bracket-noise = { path = "../bracket-noise", version = "~0.8.2" }

--- a/bracket-bevy/Cargo.toml
+++ b/bracket-bevy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bracket-bevy"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Herbert Wolverson <herberticus@gmail.com>"]
 publish = false
@@ -18,7 +18,7 @@ bevy = { git = "https://github.com/bevyengine/bevy.git" }
 parking_lot = "0.12.1"
 lazy_static = "1.4"
 bracket-random = { path = "../bracket-random" }
-bracket-color = { path = "../bracket-color", features = [ "bevy" ] }
+bracket-color = { path = "../bracket-color", features = ["bevy"] }
 bracket-geometry = { path = "../bracket-geometry", version = "~0.8.3" }
 
 [dev-dependencies]

--- a/bracket-pathfinding/Cargo.toml
+++ b/bracket-pathfinding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bracket-pathfinding"
-version = "0.8.4"
+version = "0.8.5"
 authors = ["Herbert Wolverson <herberticus@gmail.com>"]
 edition = "2018"
 publish = true
@@ -18,7 +18,7 @@ license = "MIT"
 threaded = ["rayon"]
 
 [dependencies]
-bracket-geometry = { path = "../bracket-geometry", version = "~0.8.2" }
+bracket-geometry = { path = "../bracket-geometry", version = "~0.8.3" }
 bracket-algorithm-traits = { path = "../bracket-algorithm-traits", version = "~0.8.2" }
 num-rational = { version = "0.4", default-features = false, features = ["std"] }
 rayon = { version = "1.5.0", optional = true }
@@ -26,7 +26,7 @@ smallvec = "~1"
 
 [dev-dependencies]
 crossterm = "~0.19"
-bracket-random = { path = "../bracket-random", version = "0.8.2" }
+bracket-random = { path = "../bracket-random", version = "0.8.3" }
 bracket-color = { path = "../bracket-color", version = "~0.8.2", features = [ "palette" ] }
 criterion = "0.3.4"
 

--- a/bracket-terminal/Cargo.toml
+++ b/bracket-terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bracket-terminal"
-version = "0.8.5"
+version = "0.8.6"
 authors = ["Herbert Wolverson <herberticus@gmail.com>"]
 edition = "2018"
 publish = true

--- a/bracket-terminal/Cargo.toml
+++ b/bracket-terminal/Cargo.toml
@@ -31,7 +31,7 @@ ultraviolet = "~0.8.1"
 parking_lot = { version = "~0.11.1" }
 ctrlc = { version = "~3.1", optional=true }
 anyhow = "~1.0"
-wgpu = { version = "0.11", optional=true }
+wgpu = { version = "0.13.1", optional=true }
 pollster = { version = "0.2", optional=true }
 bytemuck = {version = "1.4.0", optional=true }
 


### PR DESCRIPTION
wgpu needed to be bumped to v13.1 to keep updated with bevy standards. I also bumped the packages since if you used `bracket-pathfinding` with `bracket-bevy` it complained about differences in `bracket-geometry`.

The final change was to add your custom systems to their respective stages. Previously you created the stages, and then added the systems using `add_system` but this adds the system to the `CoreStage::Update` of bevy. I created an enum for your stages for better readability than simple strings