### PR TITLE
add point to bevy component ecs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ resolver = "2" # Enables the new Cargo resolution engine
 
 [features]
 default = [ "opengl" ]
+bevy = ["bracket-geometry/bevy"]
 specs = [ "bracket-geometry/specs" ]
 serde = [ "bracket-color/serde", "bracket-geometry/serde", "bracket-random/serde" ]
 threaded = [ "bracket-pathfinding/threaded" ]

--- a/bracket-bevy/Cargo.toml
+++ b/bracket-bevy/Cargo.toml
@@ -18,7 +18,7 @@ parking_lot = "0.12"
 lazy_static = "1.4"
 bracket-random = { path = "../bracket-random" }
 bracket-color = { path = "../bracket-color", features = [ "bevy" ] }
-bracket-geometry = { path = "../bracket-geometry", version = "~0.8.3" }
+bracket-geometry = { path = "../bracket-geometry", version = "~0.8.3", features = [ "bevy" ] }
 
 [dev-dependencies]
 bracket-pathfinding = { path = "../bracket-pathfinding", version = "~0.8.4" }

--- a/bracket-geometry/Cargo.toml
+++ b/bracket-geometry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bracket-geometry"
-version = "0.8.3"
+version = "0.8.4"
 authors = ["Herbert Wolverson <herberticus@gmail.com>"]
 edition = "2018"
 publish = true
@@ -13,9 +13,10 @@ categories = ["game-engines", "graphics"]
 license = "MIT"
 
 [dependencies]
-ultraviolet = "~0.9"
-serde = { version = "~1.0.110", features = ["derive"], optional = true }
-specs = { version = "~0", optional = true }
+serde = { version = "~1.0.139", features = ["derive"], optional = true }
+specs = { version = "~0.18.0", optional = true }
+bevy = { version = "~0.8.0", optional = true }
+ultraviolet = "~0.9.0"
 
 [dev-dependencies]
 crossterm = "~0.24"

--- a/bracket-geometry/src/point.rs
+++ b/bracket-geometry/src/point.rs
@@ -17,6 +17,11 @@ impl specs::prelude::Component for Point {
     type Storage = specs::prelude::VecStorage<Self>;
 }
 
+#[cfg(feature = "bevy")]
+impl bevy::ecs::component::Component for Point {
+    type Storage = bevy::ecs::component::TableStorage;
+}
+
 impl Point {
     /// Create a new point from an x/y coordinate.
     #[inline]

--- a/bracket-geometry/src/point3.rs
+++ b/bracket-geometry/src/point3.rs
@@ -16,6 +16,11 @@ impl specs::prelude::Component for Point3 {
     type Storage = specs::prelude::VecStorage<Self>;
 }
 
+#[cfg(feature = "bevy")]
+impl bevy::ecs::component::Component for Point3 {
+    type Storage = bevy::ecs::component::TableStorage;
+}
+
 impl Point3 {
     /// Create a new point from an x/y/z coordinate.
     pub fn new<T>(x: T, y: T, z: T) -> Self

--- a/rltk/Cargo.toml
+++ b/rltk/Cargo.toml
@@ -11,17 +11,18 @@ readme = "README.md"
 keywords = ["roguelike", "cp437", "ascii", "virtual-terminal", "gamedev"]
 categories = ["game-engines", "graphics"]
 license = "MIT"
-resolver = "2" # Enables the new Cargo resolution engine
+resolver = "2"                                                                                                                                              # Enables the new Cargo resolution engine
 
 [features]
-default = [ "opengl" ]
-specs = [ "bracket-lib/specs" ]
-serde = [ "bracket-lib/serde" ]
-threaded = [ "bracket-lib/threaded" ]
-opengl = [ "bracket-lib/opengl" ]
-curses = [ "bracket-lib/curses" ]
-crossterm = [ "bracket-lib/crossterm" ]
-webgpu = [ "bracket-lib/webgpu" ]
+default = ["opengl"]
+bevy = ["bracket-lib/bevy"]
+specs = ["bracket-lib/specs"]
+serde = ["bracket-lib/serde"]
+threaded = ["bracket-lib/threaded"]
+opengl = ["bracket-lib/opengl"]
+curses = ["bracket-lib/curses"]
+crossterm = ["bracket-lib/crossterm"]
+webgpu = ["bracket-lib/webgpu"]
 
 [dependencies]
 bracket-lib = { path = "../", version = "~0.8.1", default-features = false }


### PR DESCRIPTION
With Bevy becoming increasingly popular, I thought we could add it to the component tree like specs

I chose TableStorage as the default storage type. Sparse-set is also available (https://bevy-cheatbook.github.io/patterns/component-storage.html#table-storage) but this seems like a specific use case. It might fit our use case since Point could be inserted quite frequently