### PR TITLE
Remove duplicate call to post scanlines processing

### DIFF
--- a/bracket-terminal/examples/flexible.rs
+++ b/bracket-terminal/examples/flexible.rs
@@ -62,7 +62,6 @@ fn main() -> BError {
         .build()?;
 
     context.with_post_scanlines(true);
-    context.with_post_scanlines(true);
 
     let gs = State {
         x: 0.0,


### PR DESCRIPTION
I think I've picked up a duplicate line in the flexible console example.

This removes it :)