### PR TITLE
Get SpriteConsole's sprite sheet when rendering sprite

### DIFF
--- a/bracket-terminal/src/hal/gl_common/backing/shared_main_loop.rs
+++ b/bracket-terminal/src/hal/gl_common/backing/shared_main_loop.rs
@@ -165,7 +165,8 @@ pub(crate) fn render_consoles() -> BResult<()> {
                 backing.gl_draw(font, shader)?;
             }
             ConsoleBacking::Sprite { backing } => {
-                backing.gl_draw(bi.sprite_sheets[0].backing.as_ref().unwrap(), shader)?;
+                let sprite_sheet = cons.console.as_any().downcast_ref::<SpriteConsole>().unwrap().sprite_sheet;
+                backing.gl_draw(bi.sprite_sheets[sprite_sheet].backing.as_ref().unwrap(), shader)?;
             }
         }
     }


### PR DESCRIPTION
I think the expected behavior is that a `SpriteConsole` has a sprite_sheet idx and uses this to render from the correct `SpriteSheet` from `BTermInternal.sprite_sheets`. Currently though the code in `bracket-terminal/src/hal/gl_common/shared_main_loop.rs` will only ever pull from the first sprite sheet. The change I provide here gets the correct sprite sheet idx from the `SpriteConsole` so that it will render the correct sprite.

Minimal case for reproduction:
```rust 
use bracket_terminal::prelude::*;

struct State;

impl GameState for State {
    fn tick(&mut self, ctx: &mut BTerm) {
        ctx.set_active_console(0); // The console that registered the sprite_dood
        ctx.cls(); // Clear console 0
        ctx.add_sprite(Rect::with_size(1, 1, 64, 64), 0, RGBA::from_f32(1.0, 1.0, 1.0, 1.0), 0);

        ctx.set_active_console(1); // The console that registered the example tiles
        ctx.cls(); // Clear console 0
        ctx.add_sprite(Rect::with_size(1, 65, 64, 64), 0, RGBA::from_f32(1.0, 1.0, 1.0, 1.0), 0);
    }
}

fn main() -> BError {
    let ctx = BTermBuilder::new()
        .with_font("terminal8x8.png", 8, 8)
        .with_sprite_sheet(SpriteSheet::new("../resources/other_dood.png") // indexed by 0
            .add_sprite(Rect::with_size(0, 0, 16, 16)))
        .with_sprite_sheet(SpriteSheet::new("../resources/sprite_dood.png") // indexed by 1
            .add_sprite(Rect::with_size(0, 0, 85, 132)))
        .with_sprite_console(640, 480, 0) // Uses the sprite_dood SpriteSheet, indexed by 0
        .with_sprite_console(640, 480, 1) // Uses the example_tiles SpriteSheet, indexed by 1
        .build()?;

    main_loop(ctx, State)
}

```

The above code produces this output on current master, it is pulling from the first spreadsheet for both `SpriteConsoles`
![image](https://user-images.githubusercontent.com/43679332/183944006-fe3e1e29-6b59-4ad7-9a0b-3536afe402d1.png)

This PR produces this output, which has them each pulling their respective sprite sheets:
![image](https://user-images.githubusercontent.com/43679332/183944336-59b73eb7-ca54-4052-a473-d5d5e40fb9af.png)


I don't have a super deep understanding of this project's code yet so apologies if there's some glaring and obvious reason why this code is the way it is. This could also be a breaking change if some projects relied on it always pulling from the first spritesheet even when specifying others. 
