### PR TITLE
re-export color mods separately

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ webgpu = [ "bracket-terminal/webgpu" ]
 
 [dependencies]
 bracket-algorithm-traits = { path = "./bracket-algorithm-traits", version = "~0.8.2" }
-bracket-color = { path = "./bracket-color", version = "~0.8.2", features = [ "palette" ] }
+bracket-color = { path = "./bracket-color", version = "~0.8.3", features = [ "palette" ] }
 bracket-geometry = { path = "./bracket-geometry", version = "~0.8.2" }
 bracket-noise = { path = "./bracket-noise", version = "~0.8.2" }
 bracket-pathfinding = { path = "./bracket-pathfinding", version = "~0.8.2" }

--- a/bracket-color/Cargo.toml
+++ b/bracket-color/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bracket-color"
-version = "0.8.2"
+version = "0.8.3"
 authors = ["Herbert Wolverson <herberticus@gmail.com>"]
 edition = "2018"
 publish = true
@@ -17,13 +17,13 @@ palette = [ "lazy_static", "parking_lot" ]
 
 [dependencies]
 serde = { version = "~1.0.110", features = ["derive"], optional = true }
-crossterm = { version = "~0.24", optional = true }
+crossterm = { version = "~0.25", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 parking_lot = { version = "~0.12", optional = true }
 bevy = { version = "0.8", optional = true }
 
 [dev-dependencies]
-crossterm = "~0.24"
+crossterm = "~0.25"
 
 [[example]]
 name = "colors"

--- a/bracket-color/examples/util/mod.rs
+++ b/bracket-color/examples/util/mod.rs
@@ -2,7 +2,7 @@ use bracket_color::prelude::*;
 use crossterm::queue;
 use crossterm::style::{Print, SetForegroundColor};
 use std::convert::TryInto;
-use std::io::{stdout, Write};
+use std::io::stdout;
 
 pub fn print_color(color: RGB, text: &str) {
     queue!(stdout(), SetForegroundColor(color.try_into().unwrap())).expect("Command Fail");

--- a/bracket-color/src/lib.rs
+++ b/bracket-color/src/lib.rs
@@ -31,20 +31,20 @@
 extern crate lazy_static;
 
 /// Import color pair support
-mod color_pair;
+pub mod color_pair;
 /// Import HSV color support
-mod hsv;
+pub mod hsv;
 /// Import Lerp as an iterator
-mod lerpit;
+pub mod lerpit;
 /// Import library of named colors
-mod named;
+pub mod named;
 /// Import Palette support
 #[cfg(feature = "palette")]
-mod palette;
+pub mod palette;
 /// Import RGB color support
-mod rgb;
+pub mod rgb;
 /// Import RGBA color support
-mod rgba;
+pub mod rgba;
 
 /// Exports the color functions/types in the `prelude` namespace.
 pub mod prelude {


### PR DESCRIPTION
Publish color mods separately (in addition to prelude) to make it easier to specifically use parts of the library. 