### PR TITLE
Fix tiles incrementing each frame

### DIFF
--- a/bracket-terminal/src/consoles/flexible_console.rs
+++ b/bracket-terminal/src/consoles/flexible_console.rs
@@ -5,6 +5,8 @@ use crate::prelude::{
 use bracket_color::prelude::RGBA;
 use bracket_geometry::prelude::{PointF, Rect};
 use bracket_rex::prelude::XpColor;
+use ultraviolet::Vec2;
+
 use std::any::Any;
 
 /// Internal storage structure for sparse tiles.
@@ -106,11 +108,17 @@ impl Console for FlexiConsole {
     /// Clear the screen.
     fn cls(&mut self) {
         self.is_dirty = true;
-        for tile in &mut self.tiles {
-            tile.glyph = 32;
-            tile.fg = RGBA::from_u8(255, 255, 255, 255);
-            tile.bg = RGBA::from_u8(0, 0, 0, 255);
-        }
+        self.tiles.clear();
+
+        self.tiles.push(FlexiTile {
+            glyph: 32,
+            fg: RGBA::from_u8(255, 255, 255, 255),
+            bg: RGBA::from_u8(0, 0, 0, 255),
+            rotation: 0.,
+            scale: Vec2::new(0., 0.),
+            z_order: 0,
+            position: Vec2::new(0., 0.),
+        });
     }
 
     /// Clear the screen. Since we don't HAVE a background, it doesn't use it.


### PR DESCRIPTION
Fixes #278 

The tiles are not cleared on each tick so they keep incrementing, causing the app to slow down.

This clears the tiles on each tick and maintains the previous fix for #278. Forcing a new tile after clearing, redraws all tiles. It's not elegant and I'm still looking into this. 

Before (excuse the gif rendering issue)
![BracketRenderBefore](https://user-images.githubusercontent.com/294376/188324067-f658db46-4522-4e4a-acd0-ca7e7ed4360c.gif)

After (excuse the gif rendering issue)
![BracketRenderAfter](https://user-images.githubusercontent.com/294376/188324072-0732b4ae-1e85-4500-9402-2a6dfec61954.gif)
