### PR TITLE
add reflect for saveload in bevy

### DIFF
--- a/bracket-geometry/src/point.rs
+++ b/bracket-geometry/src/point.rs
@@ -2,10 +2,17 @@ use std::convert::{From, TryInto};
 use std::ops;
 use ultraviolet::Vec2;
 
+#[cfg(feature = "bevy")]
+use bevy::prelude::Reflect;
+
 /// A 2D floating-point position.
 pub type PointF = Vec2;
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "bevy",
+    derive(bevy::ecs::component::Component, bevy::prelude::Reflect)
+)]
 #[derive(Eq, PartialEq, Copy, Clone, Debug, Hash)]
 /// Helper struct defining a 2D point in space.
 pub struct Point {
@@ -18,11 +25,6 @@ pub struct Point {
 #[cfg(feature = "specs")]
 impl specs::prelude::Component for Point {
     type Storage = specs::prelude::VecStorage<Self>;
-}
-
-#[cfg(feature = "bevy")]
-impl bevy::ecs::component::Component for Point {
-    type Storage = bevy::ecs::component::TableStorage;
 }
 
 impl Point {
@@ -80,9 +82,9 @@ impl Point {
     }
 
     /// Converts the point to a usize tuple
-    /// 
+    ///
     /// # Panics
-    /// 
+    ///
     /// This can panic if X or Y are not convertible to a `usize`.
     #[must_use]
     pub fn to_unsigned_tuple(self) -> (usize, usize) {

--- a/bracket-geometry/src/point.rs
+++ b/bracket-geometry/src/point.rs
@@ -3,17 +3,20 @@ use std::ops;
 use ultraviolet::Vec2;
 
 #[cfg(feature = "bevy")]
+use bevy::ecs::reflect::ReflectComponent;
+#[cfg(feature = "bevy")]
 use bevy::prelude::Reflect;
 
 /// A 2D floating-point position.
 pub type PointF = Vec2;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "bevy",
     derive(bevy::ecs::component::Component, bevy::prelude::Reflect)
 )]
-#[derive(Eq, PartialEq, Copy, Clone, Debug, Hash)]
+#[cfg_attr(feature = "bevy", reflect(Component))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Default, Eq, PartialEq, Copy, Clone, Debug, Hash)]
 /// Helper struct defining a 2D point in space.
 pub struct Point {
     /// The point's X location

--- a/bracket-geometry/src/point3.rs
+++ b/bracket-geometry/src/point3.rs
@@ -2,7 +2,14 @@ use std::convert::{From, TryInto};
 use std::ops;
 use ultraviolet::Vec3;
 
+#[cfg(feature = "bevy")]
+use bevy::prelude::Reflect;
+
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "bevy",
+    derive(bevy::ecs::component::Component, bevy::prelude::Reflect)
+)]
 #[derive(Eq, PartialEq, Copy, Clone, Debug)]
 /// Helper struct defining a 2D point in space.
 pub struct Point3 {
@@ -17,11 +24,6 @@ pub struct Point3 {
 #[cfg(feature = "specs")]
 impl specs::prelude::Component for Point3 {
     type Storage = specs::prelude::VecStorage<Self>;
-}
-
-#[cfg(feature = "bevy")]
-impl bevy::ecs::component::Component for Point3 {
-    type Storage = bevy::ecs::component::TableStorage;
 }
 
 impl Point3 {

--- a/bracket-geometry/src/point3.rs
+++ b/bracket-geometry/src/point3.rs
@@ -3,14 +3,17 @@ use std::ops;
 use ultraviolet::Vec3;
 
 #[cfg(feature = "bevy")]
+use bevy::ecs::reflect::ReflectComponent;
+#[cfg(feature = "bevy")]
 use bevy::prelude::Reflect;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "bevy",
     derive(bevy::ecs::component::Component, bevy::prelude::Reflect)
 )]
-#[derive(Eq, PartialEq, Copy, Clone, Debug)]
+#[cfg_attr(feature = "bevy", reflect(Component))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Default, Eq, PartialEq, Copy, Clone, Debug)]
 /// Helper struct defining a 2D point in space.
 pub struct Point3 {
     /// The 3D point's X location


### PR DESCRIPTION
Recently I inplemented a saveload system for bevy. It requires marking all components with `Reflect` derive and registering them within the app. This should allow for the point type to be easily seraialized/deserialized.

https://github.com/bevyengine/bevy/blob/main/examples/scene/scene.rs

EDIT: 

This makes 1 assumption that I added `Default` Derive. Bevy reflect requires that default be present