### PR TITLE
export bracket-camera; add check for camera q

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,4 +57,5 @@ members = [
     "rltk",
     "bracket-rex",
     "bracket-embedding",
+    "bracket-bevy"
 ]

--- a/bracket-bevy/src/builder/mod.rs
+++ b/bracket-bevy/src/builder/mod.rs
@@ -8,3 +8,5 @@ mod loader_system;
 pub(crate) use loader_system::*;
 mod image_fixer;
 pub(crate) use image_fixer::*;
+
+pub use loader_system::BracketCamera;

--- a/bracket-bevy/src/consoles/mod.rs
+++ b/bracket-bevy/src/consoles/mod.rs
@@ -130,7 +130,7 @@ pub(crate) trait ConsoleFrontEnd: Sync + Send {
     fn get_font_index(&self) -> usize;
 }
 
-#[derive(PartialEq, Copy, Clone, Debug)]
+#[derive(Eq, PartialEq, Copy, Clone, Debug)]
 pub enum TextAlign {
     Left,
     Center,

--- a/bracket-bevy/src/consoles/update_system.rs
+++ b/bracket-bevy/src/consoles/update_system.rs
@@ -102,7 +102,12 @@ pub(crate) fn update_mouse_position(
 ) {
     // Modified from: https://bevy-cheatbook.github.io/cookbook/cursor2world.html
     // Bevy really needs a nicer way to do this
-    let (camera, camera_transform) = q_camera.single();
+    let (camera, camera_transform) = if let Ok(camera_q) = q_camera.get_single() {
+        camera_q
+    } else {
+        return;
+    };
+
     let wnd = if let RenderTarget::Window(id) = camera.target {
         wnds.get(id)
     } else {

--- a/bracket-bevy/src/lib.rs
+++ b/bracket-bevy/src/lib.rs
@@ -16,8 +16,8 @@ pub type FontCharType = u16;
 
 pub mod prelude {
     pub use crate::{
-        consoles::TextAlign, cp437::*, textblock::*, BTermBuilder, BracketContext, DrawBatch,
-        RandomNumbers, TerminalScalingMode, VirtualConsole,
+        consoles::TextAlign, cp437::*, textblock::*, BTermBuilder, BracketCamera, BracketContext,
+        DrawBatch, RandomNumbers, TerminalScalingMode, VirtualConsole,
     };
     pub use bracket_color::prelude::*;
     pub use bracket_geometry::prelude::*;


### PR DESCRIPTION
If a user add `with_ortho_camera(false)` it throws an error on the update mouse position system since the camera_q returns `NoEntities`. This exports the camera struct to be used outside of bracket-bevy, and adds a check to make sure the camera exist first