### PR TITLE
astar: Switch from std hashmap to hashbrown

### DIFF
--- a/bracket-pathfinding/Cargo.toml
+++ b/bracket-pathfinding/Cargo.toml
@@ -23,6 +23,7 @@ bracket-algorithm-traits = { path = "../bracket-algorithm-traits", version = "~0
 num-rational = { version = "0.4", default-features = false, features = ["std"] }
 rayon = { version = "1.5.0", optional = true }
 smallvec = "~1"
+hashbrown = "0.13.2"
 
 [dev-dependencies]
 crossterm = "~0.25"

--- a/bracket-pathfinding/src/astar.rs
+++ b/bracket-pathfinding/src/astar.rs
@@ -1,6 +1,7 @@
 use bracket_algorithm_traits::prelude::BaseMap;
+use hashbrown::HashMap;
 use std::cmp::Ordering;
-use std::collections::{BinaryHeap, HashMap};
+use std::collections::BinaryHeap;
 use std::convert::TryInto;
 
 /// Bail out if the A* search exceeds this many steps.


### PR DESCRIPTION
This offers a 30% improvement on the benchmark with zero other changes:

```
a_star_test_map         time:   [24.398 µs 24.607 µs 24.873 µs]
                        change: [-31.335% -30.672% -29.858%] (p = 0.00 < 0.05)
```

Real-world results were similar.