### PR TITLE
Fix truncated doc comment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub mod noise {
 }
 /// bracket-pathfinding (in conjunction with bracket-algorithm-traits) provides
 /// pathfinding functionality. A-Star (A*) and Dijkstra are supported. It also
-// provides field of view (FOV) functionality.
+/// provides field of view (FOV) functionality.
 pub mod pathfinding {
     pub use bracket_pathfinding::prelude::*;
 }


### PR DESCRIPTION
The doc comment for the `pathfinding` module is truncated:

<img width="980" alt="Screen Shot 2023-04-28 at 10 25 45 AM" src="https://user-images.githubusercontent.com/1037028/235175914-f7f4fed6-46cb-49e4-9db6-f26c94e0a7cf.png">

the last line is a regular comment instead of a doc comment. This PR promotes that last line to a doc comment to complete the thought in the docs.
