### PR TITLE
Update bracket_bevy to Bevy 0.15

### DIFF
--- a/bracket-bevy/Cargo.toml
+++ b/bracket-bevy/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["game-engines", "graphics"]
 license = "MIT"
 
 [dependencies]
-bevy = "0.9"
+bevy = { version = "0.15", features = [ "wayland" ] }
 parking_lot = "0.12"
 lazy_static = "1.4"
 bracket-random = { path = "../bracket-random" }

--- a/bracket-bevy/examples/bevy_a_star_mouse.rs
+++ b/bracket-bevy/examples/bevy_a_star_mouse.rs
@@ -5,9 +5,9 @@ use bracket_pathfinding::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(BTermBuilder::simple_80x50().with_random_number_generator(true))
-        .add_startup_system(setup)
-        .add_system(tick)
+        .add_plugins(BTermBuilder::simple_80x50().with_random_number_generator(true))
+        .add_systems(Startup, setup)
+        .add_systems(Update, tick)
         .run();
 }
 
@@ -134,7 +134,7 @@ impl Algorithm2D for State {
     }
 }
 
-fn tick(ctx: Res<BracketContext>, mut state: ResMut<State>, mouse: Res<Input<MouseButton>>) {
+fn tick(ctx: Res<BracketContext>, mut state: ResMut<State>, mouse: Res<ButtonInput<MouseButton>>) {
     // Let's use batched drawing
     let mut draw_batch = ctx.new_draw_batch();
 

--- a/bracket-bevy/examples/bevy_alpha.rs
+++ b/bracket-bevy/examples/bevy_alpha.rs
@@ -9,8 +9,8 @@ fn main() {
 
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(bterm)
-        .add_system(tick)
+        .add_plugins(bterm)
+        .add_systems(Update, tick)
         .run();
 }
 

--- a/bracket-bevy/examples/bevy_batch_z_order.rs
+++ b/bracket-bevy/examples/bevy_batch_z_order.rs
@@ -4,8 +4,8 @@ use bracket_bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(BTermBuilder::simple_80x50())
-        .add_system(tick)
+        .add_plugins(BTermBuilder::simple_80x50())
+        .add_systems(Update, tick)
         .run();
 }
 

--- a/bracket-bevy/examples/bevy_benchmark.rs
+++ b/bracket-bevy/examples/bevy_benchmark.rs
@@ -6,8 +6,8 @@ fn main() {
 
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(bterm)
-        .add_system(tick)
+        .add_plugins(bterm)
+        .add_systems(Update, tick)
         .run();
 }
 

--- a/bracket-bevy/examples/bevy_benchmark_scalable.rs
+++ b/bracket-bevy/examples/bevy_benchmark_scalable.rs
@@ -8,8 +8,8 @@ fn main() {
 
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(bterm)
-        .add_system(tick)
+        .add_plugins(bterm)
+        .add_systems(Update, tick)
         .run();
 }
 

--- a/bracket-bevy/examples/bevy_colorfont.rs
+++ b/bracket-bevy/examples/bevy_colorfont.rs
@@ -8,8 +8,8 @@ fn main() {
 
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(bracket)
-        .add_system(tick)
+        .add_plugins(bracket)
+        .add_systems(Update, tick)
         .run();
 }
 

--- a/bracket-bevy/examples/bevy_dwarfmap.rs
+++ b/bracket-bevy/examples/bevy_dwarfmap.rs
@@ -6,8 +6,8 @@ use bracket_pathfinding::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(BTermBuilder::simple_80x50())
-        .add_system(tick)
+        .add_plugins(BTermBuilder::simple_80x50())
+        .add_systems(Update, tick)
         .run();
 }
 
@@ -196,7 +196,7 @@ impl Algorithm3D for State {
     }
 }
 
-fn tick(ctx: Res<BracketContext>, mut state: Local<State>, mouse: Res<Input<MouseButton>>) {
+fn tick(ctx: Res<BracketContext>, mut state: Local<State>, mouse: Res<ButtonInput<MouseButton>>) {
     // Clear the screen
     ctx.cls();
 

--- a/bracket-bevy/examples/bevy_hello_minimal.rs
+++ b/bracket-bevy/examples/bevy_hello_minimal.rs
@@ -4,8 +4,8 @@ use bracket_bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(BTermBuilder::simple_80x50())
-        .add_system(tick)
+        .add_plugins(BTermBuilder::simple_80x50())
+        .add_systems(Update, tick)
         .run();
 }
 

--- a/bracket-bevy/examples/bevy_hello_terminal.rs
+++ b/bracket-bevy/examples/bevy_hello_terminal.rs
@@ -4,16 +4,19 @@ use bracket_bevy::prelude::*;
 fn main() {
     let bterm = BTermBuilder::simple_80x50()
         .with_named_color("blue", BLUE)
-        .with_named_color("pink", Color::PINK);
+        .with_named_color(
+            "pink",
+            bracket_color::rgba::RGBA::from_f32(255.0, 182.0, 193.0, 1.0),
+        );
 
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(bterm)
+        .add_plugins(bterm)
         .insert_resource(State {
             y: 0,
             going_down: true,
         })
-        .add_system(tick)
+        .add_systems(Update, tick)
         .run();
 }
 

--- a/bracket-bevy/examples/bevy_resize_terminal.rs
+++ b/bracket-bevy/examples/bevy_resize_terminal.rs
@@ -4,10 +4,10 @@ use bracket_bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(
+        .add_plugins(
             BTermBuilder::simple_80x50().with_scaling_mode(TerminalScalingMode::ResizeTerminals),
         )
-        .add_system(tick)
+        .add_systems(Update, tick)
         .run();
 }
 

--- a/bracket-bevy/examples/bevy_roguelike_tutorial_4/main.rs
+++ b/bracket-bevy/examples/bevy_roguelike_tutorial_4/main.rs
@@ -14,9 +14,9 @@ pub use rect::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(BTermBuilder::simple_80x50().with_random_number_generator(true))
-        .add_startup_system(setup)
-        .add_system(tick)
+        .add_plugins(BTermBuilder::simple_80x50().with_random_number_generator(true))
+        .add_systems(Startup, setup)
+        .add_systems(Update, tick)
         .run();
 }
 
@@ -41,7 +41,7 @@ fn setup(mut commands: Commands, rng: Res<RandomNumbers>) {
 fn tick(
     ctx: Res<BracketContext>,
     map: Res<Map>,
-    keyboard: Res<Input<KeyCode>>,
+    keyboard: Res<ButtonInput<KeyCode>>,
     mut queries: ParamSet<(
         Query<&mut Position, With<Player>>,
         Query<(&Position, &Renderable)>,

--- a/bracket-bevy/examples/bevy_roguelike_tutorial_4/player.rs
+++ b/bracket-bevy/examples/bevy_roguelike_tutorial_4/player.rs
@@ -1,24 +1,24 @@
 use bevy::prelude::*;
 
-pub fn player_input(keyboard: &Input<KeyCode>) -> (i32, i32) {
-    if keyboard.just_pressed(KeyCode::Left)
+pub fn player_input(keyboard: &ButtonInput<KeyCode>) -> (i32, i32) {
+    if keyboard.just_pressed(KeyCode::ArrowLeft)
         || keyboard.just_pressed(KeyCode::Numpad4)
-        || keyboard.just_pressed(KeyCode::H)
+        || keyboard.just_pressed(KeyCode::KeyH)
     {
         (-1, 0)
-    } else if keyboard.just_pressed(KeyCode::Right)
+    } else if keyboard.just_pressed(KeyCode::ArrowRight)
         || keyboard.just_pressed(KeyCode::Numpad6)
-        || keyboard.just_pressed(KeyCode::L)
+        || keyboard.just_pressed(KeyCode::KeyL)
     {
         (1, 0)
-    } else if keyboard.just_pressed(KeyCode::Up)
+    } else if keyboard.just_pressed(KeyCode::ArrowUp)
         || keyboard.just_pressed(KeyCode::Numpad8)
-        || keyboard.just_pressed(KeyCode::K)
+        || keyboard.just_pressed(KeyCode::KeyK)
     {
         (0, -1)
-    } else if keyboard.just_pressed(KeyCode::Down)
+    } else if keyboard.just_pressed(KeyCode::ArrowDown)
         || keyboard.just_pressed(KeyCode::Numpad2)
-        || keyboard.just_pressed(KeyCode::J)
+        || keyboard.just_pressed(KeyCode::KeyJ)
     {
         (0, 1)
     } else {

--- a/bracket-bevy/examples/bevy_test.rs
+++ b/bracket-bevy/examples/bevy_test.rs
@@ -4,8 +4,8 @@ use bracket_bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(BTermBuilder::simple_80x50())
-        .add_system(tick)
+        .add_plugins(BTermBuilder::simple_80x50())
+        .add_systems(Update, tick)
         .run();
 }
 

--- a/bracket-bevy/examples/bevy_textblock.rs
+++ b/bracket-bevy/examples/bevy_textblock.rs
@@ -4,8 +4,8 @@ use bracket_bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(BTermBuilder::simple_80x50())
-        .add_system(tick)
+        .add_plugins(BTermBuilder::simple_80x50())
+        .add_systems(Update, tick)
         .run();
 }
 

--- a/bracket-bevy/examples/bevy_tiles.rs
+++ b/bracket-bevy/examples/bevy_tiles.rs
@@ -87,24 +87,24 @@ fn main() {
 
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(bterm)
-        .add_startup_system(setup)
-        .add_system(tick)
+        .add_plugins(bterm)
+        .add_systems(Startup, setup)
+        .add_systems(Update, tick)
         .run();
 }
 
-fn tick(ctx: Res<BracketContext>, mut state: ResMut<State>, keyboard: Res<Input<KeyCode>>) {
+fn tick(ctx: Res<BracketContext>, mut state: ResMut<State>, keyboard: Res<ButtonInput<KeyCode>>) {
     let mut draw_batch = ctx.new_draw_batch();
-    if keyboard.just_pressed(KeyCode::Left) {
+    if keyboard.just_pressed(KeyCode::ArrowLeft) {
         state.move_player(-1, 0)
     }
-    if keyboard.just_pressed(KeyCode::Right) {
+    if keyboard.just_pressed(KeyCode::ArrowRight) {
         state.move_player(1, 0)
     }
-    if keyboard.just_pressed(KeyCode::Up) {
+    if keyboard.just_pressed(KeyCode::ArrowUp) {
         state.move_player(0, -1)
     }
-    if keyboard.just_pressed(KeyCode::Down) {
+    if keyboard.just_pressed(KeyCode::ArrowDown) {
         state.move_player(0, 1)
     }
 

--- a/bracket-bevy/examples/bevy_two_layers_two_fonts.rs
+++ b/bracket-bevy/examples/bevy_two_layers_two_fonts.rs
@@ -12,9 +12,9 @@ fn main() {
 
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(bterm)
+        .add_plugins(bterm)
         .insert_resource(Bouncer(0))
-        .add_system(tick)
+        .add_systems(Update, tick)
         .run();
 }
 

--- a/bracket-bevy/examples/bevy_walking.rs
+++ b/bracket-bevy/examples/bevy_walking.rs
@@ -4,9 +4,9 @@ use bracket_bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(BTermBuilder::simple_80x50().with_random_number_generator(true))
-        .add_startup_system(build_state)
-        .add_system(tick)
+        .add_plugins(BTermBuilder::simple_80x50().with_random_number_generator(true))
+        .add_systems(Startup, build_state)
+        .add_systems(Update, tick)
         .run();
 }
 
@@ -83,21 +83,21 @@ impl State {
     }
 }
 
-fn tick(ctx: Res<BracketContext>, mut state: ResMut<State>, keyboard: Res<Input<KeyCode>>) {
+fn tick(ctx: Res<BracketContext>, mut state: ResMut<State>, keyboard: Res<ButtonInput<KeyCode>>) {
     // Clear the screen
     ctx.cls();
 
     // Handle keyboard
-    if keyboard.just_pressed(KeyCode::Left) {
+    if keyboard.just_pressed(KeyCode::ArrowLeft) {
         state.move_player(-1, 0)
     }
-    if keyboard.just_pressed(KeyCode::Right) {
+    if keyboard.just_pressed(KeyCode::ArrowRight) {
         state.move_player(1, 0)
     }
-    if keyboard.just_pressed(KeyCode::Up) {
+    if keyboard.just_pressed(KeyCode::ArrowUp) {
         state.move_player(0, -1)
     }
-    if keyboard.just_pressed(KeyCode::Down) {
+    if keyboard.just_pressed(KeyCode::ArrowDown) {
         state.move_player(0, 1)
     }
 

--- a/bracket-bevy/src/builder/image_fixer.rs
+++ b/bracket-bevy/src/builder/image_fixer.rs
@@ -1,10 +1,10 @@
 use bevy::{
+    image::{ImageAddressMode, ImageFilterMode, ImageSampler, ImageSamplerDescriptor},
     prelude::*,
-    render::{render_resource::SamplerDescriptor, texture::ImageSampler},
 };
 
 #[derive(Resource)]
-pub(crate) struct ImagesToLoad(pub(crate) Vec<HandleUntyped>);
+pub(crate) struct ImagesToLoad(pub(crate) Vec<UntypedHandle>);
 
 pub(crate) fn fix_images(mut fonts: ResMut<ImagesToLoad>, mut images: ResMut<Assets<Image>>) {
     if fonts.0.is_empty() {
@@ -13,15 +13,15 @@ pub(crate) fn fix_images(mut fonts: ResMut<ImagesToLoad>, mut images: ResMut<Ass
 
     for (handle, img) in images.iter_mut() {
         let mut to_remove = Vec::new();
-        if let Some(i) = fonts.0.iter().enumerate().find(|(_i, h)| h.id == handle) {
-            img.sampler_descriptor = ImageSampler::Descriptor(SamplerDescriptor {
-                label: Some("LeaveItAlone"),
-                address_mode_u: bevy::render::render_resource::AddressMode::ClampToEdge,
-                address_mode_v: bevy::render::render_resource::AddressMode::ClampToEdge,
-                address_mode_w: bevy::render::render_resource::AddressMode::ClampToEdge,
-                mag_filter: bevy::render::render_resource::FilterMode::Nearest,
-                min_filter: bevy::render::render_resource::FilterMode::Nearest,
-                mipmap_filter: bevy::render::render_resource::FilterMode::Nearest,
+        if let Some(i) = fonts.0.iter().enumerate().find(|(_i, h)| h.id() == handle) {
+            img.sampler = ImageSampler::Descriptor(ImageSamplerDescriptor {
+                label: Some(String::from("LeaveItAlone")),
+                address_mode_u: ImageAddressMode::ClampToEdge,
+                address_mode_v: ImageAddressMode::ClampToEdge,
+                address_mode_w: ImageAddressMode::ClampToEdge,
+                mag_filter: ImageFilterMode::Nearest,
+                min_filter: ImageFilterMode::Nearest,
+                mipmap_filter: ImageFilterMode::Nearest,
                 ..Default::default()
             });
             to_remove.push(i.0);

--- a/bracket-bevy/src/builder/loader_system.rs
+++ b/bracket-bevy/src/builder/loader_system.rs
@@ -3,9 +3,8 @@ use crate::{
     TerminalLayer,
 };
 use bevy::{
-    prelude::{
-        AssetServer, Assets, Camera2dBundle, Commands, Component, HandleUntyped, Mesh, Res, ResMut,
-    },
+    core_pipeline::core_2d::Camera2d,
+    prelude::{AssetServer, Assets, Commands, Component, Mesh, Res, ResMut, UntypedHandle},
     sprite::ColorMaterial,
 };
 
@@ -22,9 +21,7 @@ pub(crate) fn load_terminals(
     mut meshes: ResMut<Assets<Mesh>>,
 ) {
     if context.with_ortho_camera {
-        commands
-            .spawn(Camera2dBundle::default())
-            .insert(BracketCamera);
+        commands.spawn(Camera2d::default()).insert(BracketCamera);
     }
 
     // Setup the new context
@@ -32,11 +29,11 @@ pub(crate) fn load_terminals(
     new_context.scaling_mode = context.scaling_mode;
 
     // Load the fonts
-    let mut texture_handles = Vec::<HandleUntyped>::new();
+    let mut texture_handles = Vec::<UntypedHandle>::new();
     for font in context.fonts.iter() {
         let texture_handle = asset_server.load(&font.filename);
         let material_handle = materials.add(ColorMaterial::from(texture_handle.clone()));
-        texture_handles.push(texture_handle.clone_untyped());
+        texture_handles.push(texture_handle.clone().untyped());
         new_context.fonts.push(FontStore::new(
             texture_handle,
             material_handle,

--- a/bracket-bevy/src/consoles/simple_console/back_end/simple_no_background.rs
+++ b/bracket-bevy/src/consoles/simple_console/back_end/simple_no_background.rs
@@ -1,9 +1,9 @@
 use super::SimpleConsoleBackend;
 use crate::consoles::{scaler::FontScaler, BracketMesh, ScreenScaler, SimpleConsole};
 use bevy::{
+    asset::RenderAssetUsages,
     prelude::*,
     render::mesh::{Indices, PrimitiveTopology},
-    sprite::MaterialMesh2dBundle,
 };
 
 pub(crate) struct SimpleBackendNoBackground {
@@ -84,12 +84,15 @@ impl SimpleBackendNoBackground {
                 idx += 1;
             }
         }
-        let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
+        let mut mesh = Mesh::new(
+            PrimitiveTopology::TriangleList,
+            RenderAssetUsages::RENDER_WORLD,
+        );
         mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, vertices);
         mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
         mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uv);
         mesh.insert_attribute(Mesh::ATTRIBUTE_COLOR, colors);
-        mesh.set_indices(Some(Indices::U32(indices)));
+        mesh.insert_indices(Indices::U32(indices));
         mesh
     }
 }
@@ -107,12 +110,11 @@ impl SimpleConsoleBackend for SimpleBackendNoBackground {
     fn spawn(&self, commands: &mut Commands, material: Handle<ColorMaterial>, idx: usize) {
         if let Some(mesh_handle) = &self.mesh_handle {
             commands
-                .spawn(MaterialMesh2dBundle {
-                    mesh: mesh_handle.clone().into(),
-                    transform: Transform::default(),
-                    material,
-                    ..default()
-                })
+                .spawn((
+                    Mesh2d(mesh_handle.clone().into()),
+                    MeshMaterial2d(material),
+                    Transform::default(),
+                ))
                 .insert(BracketMesh(idx));
         }
     }

--- a/bracket-bevy/src/consoles/simple_console/back_end/simple_with_background.rs
+++ b/bracket-bevy/src/consoles/simple_console/back_end/simple_with_background.rs
@@ -1,8 +1,8 @@
 use crate::consoles::{scaler::FontScaler, BracketMesh, ScreenScaler, SimpleConsole};
 use bevy::{
+    asset::RenderAssetUsages,
     prelude::*,
     render::mesh::{Indices, PrimitiveTopology},
-    sprite::MaterialMesh2dBundle,
 };
 
 use super::SimpleConsoleBackend;
@@ -122,12 +122,15 @@ impl SimpleBackendWithBackground {
                 idx += 1;
             }
         }
-        let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
+        let mut mesh = Mesh::new(
+            PrimitiveTopology::TriangleList,
+            RenderAssetUsages::RENDER_WORLD,
+        );
         mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, vertices);
         mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
         mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uv);
         mesh.insert_attribute(Mesh::ATTRIBUTE_COLOR, colors);
-        mesh.set_indices(Some(Indices::U32(indices)));
+        mesh.insert_indices(Indices::U32(indices));
         mesh
     }
 }
@@ -145,12 +148,11 @@ impl SimpleConsoleBackend for SimpleBackendWithBackground {
     fn spawn(&self, commands: &mut Commands, material: Handle<ColorMaterial>, idx: usize) {
         if let Some(mesh_handle) = &self.mesh_handle {
             commands
-                .spawn(MaterialMesh2dBundle {
-                    mesh: mesh_handle.clone().into(),
-                    transform: Transform::default(),
-                    material,
-                    ..default()
-                })
+                .spawn((
+                    Mesh2d(mesh_handle.clone().into()),
+                    MeshMaterial2d(material),
+                    Transform::default(),
+                ))
                 .insert(BracketMesh(idx));
         }
     }

--- a/bracket-bevy/src/consoles/simple_console/terminal_glyph.rs
+++ b/bracket-bevy/src/consoles/simple_console/terminal_glyph.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::Color;
+use bevy::{color::ColorToComponents, prelude::Color};
 
 #[derive(Clone, Copy)]
 pub struct TerminalGlyph {
@@ -11,8 +11,8 @@ impl Default for TerminalGlyph {
     fn default() -> Self {
         Self {
             glyph: 32,
-            foreground: Color::WHITE.as_rgba_f32(),
-            background: Color::BLACK.as_rgba_f32(),
+            foreground: Color::WHITE.to_srgba().to_f32_array(),
+            background: Color::BLACK.to_srgba().to_f32_array(),
         }
     }
 }

--- a/bracket-bevy/src/consoles/sparse_console/back_end/sparse_no_background.rs
+++ b/bracket-bevy/src/consoles/sparse_console/back_end/sparse_no_background.rs
@@ -1,9 +1,9 @@
 use super::SparseConsoleBackend;
 use crate::consoles::{scaler::FontScaler, BracketMesh, ScreenScaler, SparseConsole};
 use bevy::{
+    asset::RenderAssetUsages,
     prelude::*,
     render::mesh::{Indices, PrimitiveTopology},
-    sprite::MaterialMesh2dBundle,
 };
 
 pub(crate) struct SparseBackendNoBackground {
@@ -83,12 +83,15 @@ impl SparseBackendNoBackground {
             index_count += 4;
         }
 
-        let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
+        let mut mesh = Mesh::new(
+            PrimitiveTopology::TriangleList,
+            RenderAssetUsages::RENDER_WORLD,
+        );
         mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, vertices);
         mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
         mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uv);
         mesh.insert_attribute(Mesh::ATTRIBUTE_COLOR, colors);
-        mesh.set_indices(Some(Indices::U32(indices)));
+        mesh.insert_indices(Indices::U32(indices));
         mesh
     }
 }
@@ -106,12 +109,11 @@ impl SparseConsoleBackend for SparseBackendNoBackground {
     fn spawn(&self, commands: &mut Commands, material: Handle<ColorMaterial>, idx: usize) {
         if let Some(mesh_handle) = &self.mesh_handle {
             commands
-                .spawn(MaterialMesh2dBundle {
-                    mesh: mesh_handle.clone().into(),
-                    transform: Transform::default(),
-                    material,
-                    ..default()
-                })
+                .spawn((
+                    Mesh2d(mesh_handle.clone().into()),
+                    MeshMaterial2d(material),
+                    Transform::default(),
+                ))
                 .insert(BracketMesh(idx));
         }
     }

--- a/bracket-bevy/src/consoles/sparse_console/back_end/sparse_with_background.rs
+++ b/bracket-bevy/src/consoles/sparse_console/back_end/sparse_with_background.rs
@@ -1,9 +1,9 @@
 use super::SparseConsoleBackend;
 use crate::consoles::{scaler::FontScaler, BracketMesh, ScreenScaler, SparseConsole};
 use bevy::{
+    asset::RenderAssetUsages,
     prelude::*,
     render::mesh::{Indices, PrimitiveTopology},
-    sprite::MaterialMesh2dBundle,
 };
 
 pub(crate) struct SparseBackendWithBackground {
@@ -114,12 +114,15 @@ impl SparseBackendWithBackground {
             index_count += 4;
         }
 
-        let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
+        let mut mesh = Mesh::new(
+            PrimitiveTopology::TriangleList,
+            RenderAssetUsages::RENDER_WORLD,
+        );
         mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, vertices);
         mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
         mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uv);
         mesh.insert_attribute(Mesh::ATTRIBUTE_COLOR, colors);
-        mesh.set_indices(Some(Indices::U32(indices)));
+        mesh.insert_indices(Indices::U32(indices));
         mesh
     }
 }
@@ -137,12 +140,11 @@ impl SparseConsoleBackend for SparseBackendWithBackground {
     fn spawn(&self, commands: &mut Commands, material: Handle<ColorMaterial>, idx: usize) {
         if let Some(mesh_handle) = &self.mesh_handle {
             commands
-                .spawn(MaterialMesh2dBundle {
-                    mesh: mesh_handle.clone().into(),
-                    transform: Transform::default(),
-                    material,
-                    ..default()
-                })
+                .spawn((
+                    Mesh2d(mesh_handle.clone().into()),
+                    MeshMaterial2d(material),
+                    Transform::default(),
+                ))
                 .insert(BracketMesh(idx));
         }
     }

--- a/bracket-bevy/src/consoles/update_system.rs
+++ b/bracket-bevy/src/consoles/update_system.rs
@@ -1,11 +1,9 @@
 use crate::{BracketCamera, BracketContext, TerminalScalingMode};
 use bevy::{
-    diagnostic::{Diagnostics, FrameTimeDiagnosticsPlugin},
-    ecs::event::Events,
+    diagnostic::{DiagnosticsStore, FrameTimeDiagnosticsPlugin},
     prelude::*,
     render::camera::RenderTarget,
-    sprite::Mesh2dHandle,
-    window::WindowResized,
+    window::{PrimaryWindow, WindowRef, WindowResized},
 };
 
 use super::{BracketMesh, ScreenScaler};
@@ -13,10 +11,10 @@ use super::{BracketMesh, ScreenScaler};
 pub(crate) fn update_consoles(
     mut ctx: ResMut<BracketContext>,
     mut meshes: ResMut<Assets<Mesh>>,
-    find_mesh: Query<(&BracketMesh, &Mesh2dHandle)>,
+    find_mesh: Query<(&BracketMesh, &Mesh2d)>,
     scaler: Res<ScreenScaler>,
 ) {
-    let mut new_meshes: Vec<(Mesh2dHandle, Mesh2dHandle, bool)> = Vec::new();
+    let mut new_meshes: Vec<(Mesh2d, Mesh2d, bool)> = Vec::new();
     {
         let mut terms = ctx.terminals.lock();
         for (id, handle) in find_mesh.iter() {
@@ -38,17 +36,17 @@ pub(crate) fn replace_meshes(
     mut ctx: ResMut<BracketContext>,
     mut ev_asset: EventReader<AssetEvent<Mesh>>,
     mut meshes: ResMut<Assets<Mesh>>,
-    mut update_mesh: Query<&mut Mesh2dHandle, With<BracketMesh>>,
+    mut update_mesh: Query<&mut Mesh2d, With<BracketMesh>>,
 ) {
-    for ev in ev_asset.iter() {
-        if let AssetEvent::Created { handle } = ev {
+    for ev in ev_asset.read() {
+        if let AssetEvent::Added { id } = ev {
             for (old, new, done) in ctx.mesh_replacement.iter_mut() {
-                if handle.id() == new.0.id() {
-                    update_mesh.for_each_mut(|mut m| {
+                if *id == new.0.id() {
+                    for mut m in update_mesh.iter_mut() {
                         if old.0.id() == m.0.id() {
                             *m = new.clone();
                         }
-                    });
+                    }
                     *done = true;
                 }
             }
@@ -56,19 +54,19 @@ pub(crate) fn replace_meshes(
     }
 
     for (old, _, _) in ctx.mesh_replacement.iter().filter(|(_, _, done)| *done) {
-        meshes.remove(old.0.clone());
+        meshes.remove(old.0.id().clone());
     }
     ctx.mesh_replacement.retain(|(_, _, done)| !done);
 }
 
-pub(crate) fn update_timing(mut ctx: ResMut<BracketContext>, diagnostics: Res<Diagnostics>) {
-    if let Some(fps_diagnostic) = diagnostics.get(FrameTimeDiagnosticsPlugin::FPS) {
+pub(crate) fn update_timing(mut ctx: ResMut<BracketContext>, diagnostics: Res<DiagnosticsStore>) {
+    if let Some(fps_diagnostic) = diagnostics.get(&FrameTimeDiagnosticsPlugin::FPS) {
         if let Some(fps_avg) = fps_diagnostic.measurement() {
             ctx.fps = fps_avg.value.round();
         }
     }
 
-    if let Some(frame_time) = diagnostics.get(FrameTimeDiagnosticsPlugin::FRAME_TIME) {
+    if let Some(frame_time) = diagnostics.get(&FrameTimeDiagnosticsPlugin::FRAME_TIME) {
         if let Some(frame_time_avg) = frame_time.measurement() {
             ctx.frame_time_ms = (frame_time_avg.value * 1000.0).round();
         }
@@ -77,11 +75,10 @@ pub(crate) fn update_timing(mut ctx: ResMut<BracketContext>, diagnostics: Res<Di
 
 pub(crate) fn window_resize(
     mut context: ResMut<BracketContext>,
-    resize_event: Res<Events<WindowResized>>,
+    mut reader: EventReader<WindowResized>,
     mut scaler: ResMut<ScreenScaler>,
 ) {
-    let mut reader = resize_event.get_reader();
-    for e in reader.iter(&resize_event) {
+    for e in reader.read() {
         scaler.set_screen_size(e.width, e.height);
         if let TerminalScalingMode::ResizeTerminals = context.scaling_mode {
             context.resize_terminals(&scaler);
@@ -95,35 +92,37 @@ pub(crate) fn apply_all_batches(mut context: ResMut<BracketContext>) {
 }
 
 pub(crate) fn update_mouse_position(
-    wnds: Res<Windows>,
+    // wnds: Res<Windows>,
+    wnd_primary: Query<&Window, With<PrimaryWindow>>,
+    wnd: Query<&Window>,
     q_camera: Query<(&Camera, &GlobalTransform), With<BracketCamera>>,
     mut context: ResMut<BracketContext>,
     scaler: Res<ScreenScaler>,
 ) {
     // Modified from: https://bevy-cheatbook.github.io/cookbook/cursor2world.html
-    // Bevy really needs a nicer way to do this
-    let (camera, camera_transform) = q_camera.single();
-    let wnd = if let RenderTarget::Window(id) = camera.target {
-        wnds.get(id)
-    } else {
-        wnds.get_primary()
-    };
+    for (camera, camera_transform) in &q_camera {
+        // get the window the camera is rendering to
+        let window = match camera.target {
+            // the camera is rendering to the primary window
+            RenderTarget::Window(WindowRef::Primary) => wnd_primary.single(),
+            // the camera is rendering to some other window
+            RenderTarget::Window(WindowRef::Entity(e_window)) => wnd.get(e_window).unwrap(),
+            // the camera is rendering to something else (like a texture), not a window
+            _ => {
+                // skip this camera
+                continue;
+            }
+        };
 
-    let wnd = if let Some(wnd) = wnd {
-        wnd
-    } else {
-        return;
-    };
-
-    if let Some(screen_pos) = wnd.cursor_position() {
-        let window_size = Vec2::new(wnd.width() as f32, wnd.height() as f32);
-        let ndc = (screen_pos / window_size) * 2.0 - Vec2::ONE;
-        let ndc_to_world = camera_transform.compute_matrix() * camera.projection_matrix().inverse();
-        let world_pos = ndc_to_world.project_point3(ndc.extend(-1.0));
-        let world_pos: Vec2 = world_pos.truncate();
-
-        let result = (world_pos.x, world_pos.y);
-
-        context.set_mouse_pixel_position(result, &scaler);
+        // check if the cursor is inside the window and get its position
+        // then, ask bevy to convert into world coordinates, and truncate to discard Z
+        if let Some(world_position) = window
+            .cursor_position()
+            .and_then(|cursor| camera.viewport_to_world(camera_transform, cursor).ok())
+            .map(|ray| ray.origin.truncate())
+        {
+            // worldcursor.0 = world_position;
+            context.set_mouse_pixel_position((world_position.x, world_position.y), &scaler);
+        }
     }
 }

--- a/bracket-bevy/src/context.rs
+++ b/bracket-bevy/src/context.rs
@@ -3,7 +3,10 @@ use crate::{
     fonts::FontStore,
     FontCharType, TerminalScalingMode,
 };
-use bevy::{sprite::Mesh2dHandle, utils::HashMap, prelude::Resource};
+use bevy::{
+    prelude::{Mesh2d, Resource},
+    utils::HashMap,
+};
 use bracket_color::prelude::RGBA;
 use bracket_geometry::prelude::{Point, Rect};
 use parking_lot::Mutex;
@@ -16,7 +19,7 @@ pub struct BracketContext {
     pub(crate) color_palette: HashMap<String, RGBA>,
     pub fps: f64,
     pub frame_time_ms: f64,
-    pub(crate) mesh_replacement: Vec<(Mesh2dHandle, Mesh2dHandle, bool)>,
+    pub(crate) mesh_replacement: Vec<(Mesh2d, Mesh2d, bool)>,
     pub(crate) scaling_mode: TerminalScalingMode,
     command_buffers: Mutex<Vec<(usize, DrawBatch)>>,
     mouse_pixels: (f32, f32),

--- a/bracket-terminal/Cargo.toml
+++ b/bracket-terminal/Cargo.toml
@@ -29,7 +29,7 @@ crossterm = { version = "~0.25", optional = true }
 pancurses = { version = "0.17", optional = true }
 ultraviolet = "~0.9"
 parking_lot = { version = "~0.12" }
-ctrlc = { version = "~3.2", optional=true }
+ctrlc = { version = "~3.4", optional=true }
 anyhow = "~1.0"
 wgpu = { version = "0.13", optional=true }
 pollster = { version = "0.2", optional=true }
@@ -37,7 +37,7 @@ bytemuck = {version = "1.4.0", optional=true }
 
 [target.'cfg(not(any(target_arch = "wasm32")))'.dependencies]
 glutin = {version = "~0.29", optional = true }
-winit = { version = "~0.27" }
+winit = { version = "~0.27"}
 spin_sleep = { version = "1.0.0", optional = true }
 
 [features]


### PR DESCRIPTION
I've made the minimal changes necessary to update bracket_bevy to update to Bevy 0.15 and run examples. 

bracket-terminal itself is not running examples due to a slice_by_raw_parts issue. 

I have removed now irrelevant dependencies but I've left alone some warnings that looked like WIP code. 